### PR TITLE
CDAP-15266 Revive mongodb Sink plugin

### DIFF
--- a/docs/MongoDB-batchsink.md
+++ b/docs/MongoDB-batchsink.md
@@ -3,12 +3,67 @@
 
 Description
 -----------
-Converts a StructuredRecord into a BSONWritable and then writes it to a MongoDB collection.
+This sink writes to a MongoDB collection.
 
 
 Configuration
 -------------
-**referenceName:** This will be used to uniquely identify this sink for lineage, annotating metadata, etc.
+**Reference Name:** Name used to uniquely identify this source for lineage, annotating metadata, etc.
 
-**connectionString:** MongoDB Connection String. Example: `mongodb://localhost:27017/analytics.users` (Macro-enabled)
-[Reference](http://docs.mongodb.org/manual/reference/connection-string)
+**Host:** Host that MongoDB is running on.
+
+**Port:** Port that MongoDB is listening to.
+
+**Database:** MongoDB database name.
+
+**Collection:** Name of the database collection to write to.
+
+**ID Field:** Which input field should be used as the document identifier. Identifier is expected to be a
+[12-byte value] or it's 24-byte [hexadecimal string] representation. If none is given, an identifier will be
+automatically generated.
+
+**Username:** User identity for connecting to the specified database.
+
+**Password:** Password to use to connect to the specified database.
+
+**Connection Arguments:** A list of arbitrary string key/value pairs as connection arguments. See
+[Connection String Options] for a full description of these arguments.
+
+[Connection String Options]:
+https://docs.mongodb.com/manual/reference/connection-string/#connections-connection-options
+
+[12-byte value]:
+https://docs.mongodb.com/manual/reference/bson-types/#objectid
+
+[hexadecimal string]:
+https://docs.mongodb.com/manual/reference/method/ObjectId/#specify-a-hexadecimal-string
+
+Data Types Mapping
+----------
+	
+    | CDAP Schema Data Type | MongoDB Data Type     | Comment                                            |
+    | --------------------- | --------------------- | -------------------------------------------------- |
+    | boolean               | Boolean               |                                                    |
+    | bytes                 | Binary data, ObjectId | 12-byte value of the identifier field is mapped to |
+    |                       |                       | ObjectId.                                          |
+    | string                | String, ObjectId      | 24-byte hexadecimal string value of the identifier |
+    |                       |                       | field is mapped to ObjectId.                       |
+    | date                  | Date                  |                                                    |
+    | double                | Double                |                                                    |
+    | decimal               | Decimal128            |                                                    |
+    | float                 | Double                |                                                    |
+    | int                   | 32-bit integer        |                                                    |
+    | long                  | 64-bit integer        |                                                    |
+    | time                  | String                | Time string in the following format: HH:mm:ss.SSS  |
+    | timestamp             | Date                  |                                                    |
+    | array                 | Array                 |                                                    |
+    | record                | Object                |                                                    |
+    | enum                  | String                |                                                    |
+    | map                   | Object                |                                                    |
+    | union                 |                       | Depends on the actual value. For example, if it's  |
+    |                       |                       | a union ["string","int","long"] and the value is   |
+    |                       |                       | actually a long, the MongoDB document will have    |
+    |                       |                       | the field as a 64-bit integer. If a different      |
+    |                       |                       | record comes in with the value as a string, the    |
+    |                       |                       | MongoDB document will end up with a String for     |
+    |                       |                       | that field.                                        |

--- a/examples/example_mongo_to_mongo.json
+++ b/examples/example_mongo_to_mongo.json
@@ -1,0 +1,98 @@
+{
+    "artifact": {
+        "name": "cdap-data-pipeline",
+        "version": "6.1.0-SNAPSHOT",
+        "scope": "SYSTEM",
+        "label": "Data Pipeline - Batch"
+    },
+    "description": "Data Pipeline Application",
+    "name": "mongo_to_mongo",
+    "config": {
+        "resources": {
+            "memoryMB": 1024,
+            "virtualCores": 1
+        },
+        "driverResources": {
+            "memoryMB": 1024,
+            "virtualCores": 1
+        },
+        "connections": [
+            {
+                "from": "MongoDBSource",
+                "to": "MongoDBSink"
+            }
+        ],
+        "comments": [],
+        "postActions": [],
+        "properties": {},
+        "processTimingEnabled": true,
+        "stageLoggingEnabled": true,
+        "stages": [
+            {
+                "name": "MongoDBSource",
+                "plugin": {
+                    "name": "MongoDB",
+                    "type": "batchsource",
+                    "label": "MongoDBSource",
+                    "artifact": {
+                        "name": "mongodb-plugins",
+                        "version": "1.3.0-SNAPSHOT",
+                        "scope": "USER"
+                    },
+                    "properties": {
+                        "host": "localhost",
+                        "port": "27017",
+                        "on-error": "fail-pipeline",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"_id\",\"type\":\"bytes\"},{\"name\":\"string\",\"type\":\"string\"},{\"name\":\"int32\",\"type\":\"int\"},{\"name\":\"double\",\"type\":\"double\"},{\"name\":\"array\",\"type\":{\"type\":\"array\",\"items\":\"string\"}},{\"name\":\"object\",\"type\":{\"type\":\"record\",\"name\":\"a57542a5c977c4dccb02186d4219c69a4\",\"fields\":[{\"name\":\"inner_field\",\"type\":\"string\"}]}},{\"name\":\"binary\",\"type\":\"bytes\"},{\"name\":\"undefined\",\"type\":[\"string\",\"null\"]},{\"name\":\"boolean\",\"type\":\"boolean\"},{\"name\":\"date\",\"type\":{\"type\":\"long\",\"logicalType\":\"timestamp-micros\"}},{\"name\":\"null\",\"type\":[\"string\",\"null\"]},{\"name\":\"symbol\",\"type\":\"string\"},{\"name\":\"long\",\"type\":\"long\"}]}",
+                        "referenceName": "MongoDBSource",
+                        "database": "${source_database_name}",
+                        "collection": "${source_collection_name}"
+                    }
+                },
+                "outputSchema": [
+                    {
+                        "name": "etlSchemaBody",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"_id\",\"type\":\"bytes\"},{\"name\":\"string\",\"type\":\"string\"},{\"name\":\"int32\",\"type\":\"int\"},{\"name\":\"double\",\"type\":\"double\"},{\"name\":\"array\",\"type\":{\"type\":\"array\",\"items\":\"string\"}},{\"name\":\"object\",\"type\":{\"type\":\"record\",\"name\":\"a57542a5c977c4dccb02186d4219c69a4\",\"fields\":[{\"name\":\"inner_field\",\"type\":\"string\"}]}},{\"name\":\"binary\",\"type\":\"bytes\"},{\"name\":\"undefined\",\"type\":[\"string\",\"null\"]},{\"name\":\"boolean\",\"type\":\"boolean\"},{\"name\":\"date\",\"type\":{\"type\":\"long\",\"logicalType\":\"timestamp-micros\"}},{\"name\":\"null\",\"type\":[\"string\",\"null\"]},{\"name\":\"symbol\",\"type\":\"string\"},{\"name\":\"long\",\"type\":\"long\"}]}"
+                    }
+                ]
+            },
+            {
+                "name": "MongoDBSink",
+                "plugin": {
+                    "name": "MongoDB",
+                    "type": "batchsink",
+                    "label": "MongoDBSink",
+                    "artifact": {
+                        "name": "mongodb-plugins",
+                        "version": "1.3.0-SNAPSHOT",
+                        "scope": "USER"
+                    },
+                    "properties": {
+                        "host": "localhost",
+                        "port": "27017",
+                        "idField": "_id",
+                        "collection": "${sink_collection_name}",
+                        "database": "${sink_database_name}",
+                        "referenceName": "MongoDBSink"
+                    }
+                },
+                "outputSchema": [
+                    {
+                        "name": "etlSchemaBody",
+                        "schema": ""
+                    }
+                ],
+                "inputSchema": [
+                    {
+                        "name": "MongoDBSource",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"_id\",\"type\":\"bytes\"},{\"name\":\"string\",\"type\":\"string\"},{\"name\":\"int32\",\"type\":\"int\"},{\"name\":\"double\",\"type\":\"double\"},{\"name\":\"array\",\"type\":{\"type\":\"array\",\"items\":\"string\"}},{\"name\":\"object\",\"type\":{\"type\":\"record\",\"name\":\"a57542a5c977c4dccb02186d4219c69a4\",\"fields\":[{\"name\":\"inner_field\",\"type\":\"string\"},{\"name\":\"binary\",\"type\":\"bytes\"}]}}]}"
+                    }
+                ]
+            }
+        ],
+        "schedule": "0 * * * *",
+        "engine": "mapreduce",
+        "numOfRecordsPreview": 100,
+        "maxConcurrentRuns": 1
+    }
+}

--- a/src/main/java/io/cdap/plugin/MongoDBConstants.java
+++ b/src/main/java/io/cdap/plugin/MongoDBConstants.java
@@ -89,4 +89,14 @@ public class MongoDBConstants {
    * Configuration property name used to specify a list of arbitrary string key/value pairs as connection arguments.
    */
   public static final String CONNECTION_ARGUMENTS = "connectionArguments";
+
+  /**
+   * Configuration property name used to specify which of the incoming fields should be used as an object identifier.
+   */
+  public static final String ID_FIELD = "idField";
+
+  /**
+   * Default identifier field name.
+   */
+  public static final String DEFAULT_ID_FIELD_NAME = "_id";
 }

--- a/src/main/java/io/cdap/plugin/batch/sink/RecordToBSONWritableTransformer.java
+++ b/src/main/java/io/cdap/plugin/batch/sink/RecordToBSONWritableTransformer.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.batch.sink;
+
+import com.mongodb.BasicDBObjectBuilder;
+import com.mongodb.DBObject;
+import com.mongodb.hadoop.io.BSONWritable;
+import io.cdap.cdap.api.common.Bytes;
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.format.UnexpectedFormatException;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.etl.api.validation.InvalidStageException;
+import io.cdap.plugin.MongoDBConstants;
+import org.bson.types.Decimal128;
+import org.bson.types.ObjectId;
+
+import java.lang.reflect.Array;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+
+/**
+ * Transforms {@link StructuredRecord} to {@link BSONWritable}.
+ */
+public class RecordToBSONWritableTransformer {
+
+  private String idFieldName;
+
+  public RecordToBSONWritableTransformer() {
+  }
+
+  /**
+   * @param idFieldName specifies which of the incoming fields should be used as an document identifier. Identifier will
+   *                    be generated if no value is specified.
+   */
+  public RecordToBSONWritableTransformer(@Nullable String idFieldName) {
+    this.idFieldName = idFieldName;
+  }
+
+  /**
+   * Transforms given {@link StructuredRecord} to {@link BSONWritable}.
+   *
+   * @param record structured record to be transformed.
+   * @return {@link BSONWritable} that corresponds to the given {@link StructuredRecord}.
+   */
+  public BSONWritable transform(StructuredRecord record) {
+    return new BSONWritable(extractRecord(null, record, idFieldName));
+  }
+
+  private DBObject extractRecord(@Nullable String fieldName, @Nullable StructuredRecord record,
+                                 @Nullable String idFieldName) {
+    if (record == null) {
+      // Return 'null' value as it is
+      return null;
+    }
+    List<Schema.Field> fields = Objects.requireNonNull(record.getSchema().getFields(), "Schema fields cannot be empty");
+    BasicDBObjectBuilder bsonBuilder = BasicDBObjectBuilder.start();
+    for (Schema.Field field : fields) {
+      // Use full field name for nested records to construct meaningful errors messages.
+      // Full field names will be in the following format: 'record_field_name.nested_record_field_name'
+      String fullFieldName = fieldName != null ? String.format("%s.%s", fieldName, field.getName()) : field.getName();
+      Schema nonNullableSchema = field.getSchema().isNullable() ? field.getSchema().getNonNullable()
+        : field.getSchema();
+
+      if (field.getName().equals(idFieldName)) {
+        ObjectId objectId = extractObjectId(fullFieldName, record.get(field.getName()), nonNullableSchema);
+        bsonBuilder.add(MongoDBConstants.DEFAULT_ID_FIELD_NAME, objectId);
+        continue;
+      }
+
+      bsonBuilder.add(field.getName(), extractValue(fullFieldName, record.get(field.getName()), nonNullableSchema));
+    }
+    return bsonBuilder.get();
+  }
+
+  private ObjectId extractObjectId(String fieldName, Object value, Schema schema) {
+    Schema.Type type = schema.getType();
+    try {
+      if (type == Schema.Type.BYTES) {
+        return value instanceof ByteBuffer ? new ObjectId((ByteBuffer) value) : new ObjectId((byte[]) value);
+      } else if (type == Schema.Type.STRING) {
+        return new ObjectId((String) value);
+      }
+      throw new UnexpectedFormatException(String.format("Identified field '%s' is expected to be of type " +
+                                                          "'bytes' or 'string', but found a '%s'.", fieldName, type));
+    } catch (IllegalArgumentException e) {
+      throw new UnexpectedFormatException(String.format("Invalid value '%s' of the identifier field '%s'.", value,
+                                                        fieldName), e);
+    }
+  }
+
+  private Object extractValue(String fieldName, Object value, Schema schema) {
+    if (value == null) {
+      // Return 'null' value as it is
+      return null;
+    }
+
+    Schema.LogicalType fieldLogicalType = schema.getLogicalType();
+    // Get values of logical types properly
+    if (fieldLogicalType != null) {
+      switch (fieldLogicalType) {
+        case TIMESTAMP_MILLIS:
+          return new Date((long) value);
+        case TIMESTAMP_MICROS:
+          return new Date(TimeUnit.MICROSECONDS.toMillis((long) value));
+        case TIME_MILLIS:
+          LocalTime time = LocalTime.ofNanoOfDay(TimeUnit.MILLISECONDS.toNanos(((Integer) value)));
+          return time.toString();
+        case TIME_MICROS:
+          LocalTime localTime = LocalTime.ofNanoOfDay(TimeUnit.MICROSECONDS.toNanos((Long) value));
+          return localTime.toString();
+        case DATE:
+          long epochDay = ((Integer) value).longValue();
+          LocalDate localDate = LocalDate.ofEpochDay(epochDay);
+          return Date.from(localDate.atStartOfDay(ZoneId.ofOffset("UTC", ZoneOffset.UTC)).toInstant());
+        case DECIMAL:
+          int scale = schema.getScale();
+          BigDecimal decimal = value instanceof ByteBuffer
+            ? new BigDecimal(new BigInteger(Bytes.toBytes((ByteBuffer) value)), scale)
+            : new BigDecimal(new BigInteger((byte[]) value), scale);
+
+          return new Decimal128(decimal);
+        default:
+          throw new UnexpectedFormatException(String.format("Field '%s' is of unsupported type '%s'", fieldName,
+                                                            fieldLogicalType.name().toLowerCase()));
+      }
+    }
+
+    Schema.Type fieldType = schema.getType();
+    switch (fieldType) {
+      case BOOLEAN:
+        return (Boolean) value;
+      case INT:
+        return (Integer) value;
+      case DOUBLE:
+        return (Double) value;
+      case FLOAT:
+        return (Float) value;
+      case BYTES:
+        if (value instanceof ByteBuffer) {
+          return Bytes.getBytes((ByteBuffer) value);
+        } else {
+          return (byte[]) value;
+        }
+      case LONG:
+        return (Long) value;
+      case STRING:
+        return (String) value;
+      case MAP:
+        return extractMap(fieldName, (Map<String, ?>) value, schema);
+      case ARRAY:
+        return extractArray(fieldName, value, schema);
+      case RECORD:
+        return extractRecord(fieldName, (StructuredRecord) value, null);
+      case UNION:
+        return extractUnion(fieldName, value, schema);
+      case ENUM:
+        String enumValue = (String) value;
+        if (!Objects.requireNonNull(schema.getEnumValues()).contains(enumValue)) {
+          throw new UnexpectedFormatException(
+            String.format("Value '%s' of the field '%s' is not enum value. Enum values are: '%s'", enumValue, fieldName,
+                          schema.getEnumValues()));
+        }
+
+        return enumValue;
+      default:
+        throw new UnexpectedFormatException(String.format("Field '%s' is of unsupported type '%s'", fieldName,
+                                                          fieldLogicalType.name().toLowerCase()));
+    }
+  }
+
+  private DBObject extractMap(String fieldName, Map<String, ?> map, Schema schema) {
+    if (map == null) {
+      // Return 'null' value as it is
+      return null;
+    }
+    Map.Entry<Schema, Schema> mapSchema = Objects.requireNonNull(schema.getMapSchema());
+
+    BasicDBObjectBuilder bsonBuilder = BasicDBObjectBuilder.start();
+    Schema valueSchema = mapSchema.getValue();
+    Schema nonNullableSchema = mapSchema.getValue().isNullable() ? valueSchema.getNonNullable() : valueSchema;
+    map.forEach((k, v) -> bsonBuilder.add(k, extractValue(fieldName, v, nonNullableSchema)));
+
+    return bsonBuilder.get();
+  }
+
+  private List extractArray(String fieldName, Object value, Schema schema) {
+    if (value == null) {
+      // Return 'null' value as it is
+      return null;
+    }
+
+    Schema componentSchema = schema.getComponentSchema();
+    Schema nonNullableSchema = componentSchema.isNullable() ? componentSchema.getNonNullable() : componentSchema;
+    List<Object> extracted = new ArrayList<>();
+    if (value.getClass().isArray()) {
+      int length = Array.getLength(value);
+      for (int i = 0; i < length; i++) {
+        Object arrayElement = Array.get(value, i);
+        extracted.add(extractValue(fieldName, arrayElement, nonNullableSchema));
+      }
+      return extracted;
+    }
+    // An 'array' field can be a java.util.Collection or an array.
+    Collection values = (Collection) value;
+    for (Object obj : values) {
+      extracted.add(extractValue(fieldName, obj, nonNullableSchema));
+    }
+    return extracted;
+  }
+
+  private Object extractUnion(String fieldName, Object value, Schema schema) {
+    if (value == null) {
+      // Return 'null' value as it is
+      return null;
+    }
+    for (Schema s : schema.getUnionSchemas()) {
+      try {
+        return extractValue(fieldName, value, s);
+      } catch (Exception e) {
+        // expected if this schema is not the correct one for the value
+      }
+    }
+    // Should never happen
+    throw new InvalidStageException(
+      String.format("None of the union schemas '%s' of the field '%s' matches the value '%s'.",
+                    schema.getUnionSchemas(), fieldName, value));
+  }
+}

--- a/src/main/java/io/cdap/plugin/batch/source/BSONObjectToRecordTransformer.java
+++ b/src/main/java/io/cdap/plugin/batch/source/BSONObjectToRecordTransformer.java
@@ -120,6 +120,7 @@ public class BSONObjectToRecordTransformer {
           ByteBuffer buffer = ByteBuffer.allocate(12);
           ObjectId objectId = (ObjectId) object;
           objectId.putToByteBuffer(buffer);
+          buffer.rewind();
           return buffer;
         }
         return object;

--- a/src/test/java/io/cdap/plugin/batch/MongoDBTest.java
+++ b/src/test/java/io/cdap/plugin/batch/MongoDBTest.java
@@ -19,7 +19,6 @@ package io.cdap.plugin.batch;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.mongodb.BasicDBObject;
 import com.mongodb.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
@@ -78,7 +77,6 @@ import org.bson.BsonNull;
 import org.bson.BsonObjectId;
 import org.bson.BsonString;
 import org.bson.BsonValue;
-import org.bson.Document;
 import org.bson.types.Decimal128;
 import org.bson.types.ObjectId;
 import org.junit.After;
@@ -87,12 +85,18 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.math.BigDecimal;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
 /**
@@ -112,45 +116,20 @@ public class MongoDBTest extends HydratorTestBase {
                                                                               CURRENT_VERSION, true);
 
   private static final String MONGO_DB = "cdap";
-  private static final String MONGO_SOURCE_COLLECTIONS = "stocks";
   private static final String MONGO_SINK_COLLECTIONS = "copy";
-  private static final String MONGO_SUPPORTED_DATA_TYPES_COLLECTIONS = "alltypes";
+  private static final String SOURCE_COLLECTIONS = "source";
 
-  private static final Schema SINK_BODY_SCHEMA = Schema.recordOf(
-    "event",
-    Schema.Field.of("ticker", Schema.of(Schema.Type.STRING)),
-    Schema.Field.of("num", Schema.of(Schema.Type.INT)),
-    Schema.Field.of("price", Schema.of(Schema.Type.DOUBLE)));
-
-  private static final Schema SOURCE_BODY_SCHEMA = Schema.recordOf(
-    "event",
-    Schema.Field.of("ticker", Schema.of(Schema.Type.STRING)),
-    Schema.Field.of("num", Schema.of(Schema.Type.INT)),
-    Schema.Field.of("price", Schema.nullableOf(Schema.of(Schema.Type.DOUBLE))),
-    Schema.Field.of("agents", Schema.nullableOf(Schema.arrayOf(Schema.nullableOf(Schema.of(Schema.Type.STRING))))));
-
-  private static final List<BsonDocument> TEST_DOCUMENTS = Arrays.asList(
-    new BsonDocument()
-      .append("ticker", new BsonString("AAPL"))
-      .append("num", new BsonInt32(10))
-      .append("price", new BsonDouble(23.23))
-      .append("agents", new BsonArray(Arrays.asList(new BsonString("a1"), new BsonString("a2")))),
-
-    new BsonDocument()
-      .append("ticker", new BsonString("ORCL"))
-      .append("num", new BsonInt32(12))
-      .append("price", new BsonDouble(10.10))
-      .append("agents", new BsonArray(Arrays.asList(new BsonString("a1"), new BsonString("a2"))))
-  );
-
-  private static final Schema SUPPORTED_DATA_TYPES_SCHEMA = Schema.recordOf(
+  private static final ZonedDateTime DATE_TIME = ZonedDateTime.now(ZoneOffset.UTC);
+  private static final Schema NESTED_SCHEMA = Schema.recordOf("", Schema.Field.of("inner_field",
+                                                                                  Schema.of(Schema.Type.STRING)));
+  private static final Schema SCHEMA = Schema.recordOf(
     "document",
     Schema.Field.of("_id", Schema.of(Schema.Type.STRING)),
     Schema.Field.of("string", Schema.of(Schema.Type.STRING)),
     Schema.Field.of("int32", Schema.of(Schema.Type.INT)),
     Schema.Field.of("double", Schema.of(Schema.Type.DOUBLE)),
-    Schema.Field.of("array",  Schema.arrayOf(Schema.nullableOf(Schema.of(Schema.Type.STRING)))),
-    Schema.Field.of("object", Schema.recordOf("", Schema.Field.of("inner_field", Schema.of(Schema.Type.STRING)))),
+    Schema.Field.of("array", Schema.arrayOf(Schema.nullableOf(Schema.of(Schema.Type.STRING)))),
+    Schema.Field.of("object", NESTED_SCHEMA),
     Schema.Field.of("object-to-map", Schema.mapOf(Schema.of(Schema.Type.STRING), Schema.of(Schema.Type.STRING))),
     Schema.Field.of("binary", Schema.of(Schema.Type.BYTES)),
     Schema.Field.of("boolean", Schema.of(Schema.Type.BOOLEAN)),
@@ -160,7 +139,40 @@ public class MongoDBTest extends HydratorTestBase {
     Schema.Field.of("decimal", Schema.decimalOf(20, 10))
   );
 
-  private static final List<BsonDocument> SUPPORTED_DATA_TYPES_TEST_DOCUMENTS = Arrays.asList(
+  private static final List<StructuredRecord> TEST_RECORDS = Arrays.asList(
+    StructuredRecord.builder(SCHEMA)
+      .set("_id", "5d079ee6d078c94008e4bb3a")
+      .set("string", "AAPL")
+      .set("int32", Integer.MIN_VALUE)
+      .set("double", Double.MIN_VALUE)
+      .set("array", Arrays.asList("a1", "a2"))
+      .set("object", StructuredRecord.builder(NESTED_SCHEMA).set("inner_field", "val").build())
+      .set("object-to-map", ImmutableMap.builder().put("key", "value").build())
+      .set("binary", "binary data".getBytes())
+      .set("boolean", false)
+      .setTimestamp("date", DATE_TIME)
+      .set("long", Long.MIN_VALUE)
+      .setDecimal("decimal", new BigDecimal("987654321.1234567890"))
+      .build(),
+
+    StructuredRecord.builder(SCHEMA)
+      .set("_id", "5d079ee6d078c94008e4bb37")
+      .set("string", "AAPL")
+      .set("int32", 10)
+      .set("double", 23.23)
+      .set("array", Arrays.asList("a1", "a2"))
+      .set("object", StructuredRecord.builder(NESTED_SCHEMA).set("inner_field", "val").build())
+      .set("object-to-map", ImmutableMap.builder().put("key", "value").build())
+      .set("binary", "binary data".getBytes())
+      .set("boolean", false)
+      .setTimestamp("date", DATE_TIME)
+      .set("long", Long.MAX_VALUE)
+      .setDecimal("decimal", new BigDecimal("0.1234567890"))
+      .build()
+  );
+
+  // Correspond to the TEST_RECORDS
+  private static final List<BsonDocument> TEST_DOCUMENTS = Arrays.asList(
     new BsonDocument()
       .append("_id", new BsonObjectId(new ObjectId("5d079ee6d078c94008e4bb3a")))
       .append("string", new BsonString("AAPL"))
@@ -171,13 +183,13 @@ public class MongoDBTest extends HydratorTestBase {
       .append("object-to-map", new BsonDocument().append("key", new BsonString("value")))
       .append("binary", new BsonBinary("binary data".getBytes()))
       .append("boolean", new BsonBoolean(false))
-      .append("date", new BsonDateTime(System.currentTimeMillis()))
+      .append("date", new BsonDateTime(DATE_TIME.toInstant().toEpochMilli()))
       .append("null", new BsonNull())
       .append("long", new BsonInt64(Long.MIN_VALUE))
       .append("decimal", new BsonDecimal128(Decimal128.parse("987654321.1234567890"))),
 
     new BsonDocument()
-      .append("_id", new BsonObjectId())
+      .append("_id", new BsonObjectId(new ObjectId("5d079ee6d078c94008e4bb37")))
       .append("string", new BsonString("AAPL"))
       .append("int32", new BsonInt32(10))
       .append("double", new BsonDouble(23.23))
@@ -186,11 +198,112 @@ public class MongoDBTest extends HydratorTestBase {
       .append("object-to-map", new BsonDocument().append("key", new BsonString("value")))
       .append("binary", new BsonBinary("binary data".getBytes()))
       .append("boolean", new BsonBoolean(false))
-      .append("date", new BsonDateTime(System.currentTimeMillis()))
+      .append("date", new BsonDateTime(DATE_TIME.toInstant().toEpochMilli()))
       .append("null", new BsonNull())
       .append("long", new BsonInt64(Long.MAX_VALUE))
       .append("decimal", new BsonDecimal128(Decimal128.parse("0.1234567890")))
-    );
+  );
+
+  private static final Schema ALL_SINK_DATATYPES_SCHEMA = Schema.recordOf(
+    "document",
+    ImmutableList.<Schema.Field>builder()
+      .addAll(SCHEMA.getFields())
+      .addAll(Arrays.asList(
+        Schema.Field.of("date-field", Schema.of(Schema.LogicalType.DATE)),
+        Schema.Field.of("float", Schema.of(Schema.Type.FLOAT)),
+        Schema.Field.of("time", Schema.of(Schema.LogicalType.TIME_MILLIS)),
+        Schema.Field.of("enum", Schema.enumWith("first", "second")),
+        Schema.Field.of("union", Schema.unionOf(Schema.of(Schema.Type.STRING), NESTED_SCHEMA))
+      )).build()
+  );
+
+  private static final List<StructuredRecord> ALL_SINK_DATATYPES_RECORDS = Arrays.asList(
+    StructuredRecord.builder(ALL_SINK_DATATYPES_SCHEMA)
+      .set("_id", "5d079ee6d078c94008e4bb4a")
+      .set("string", "AAPL")
+      .set("int32", Integer.MIN_VALUE)
+      .set("double", Double.MIN_VALUE)
+      .set("array", Arrays.asList("a1", "a2"))
+      .set("object", StructuredRecord.builder(NESTED_SCHEMA).set("inner_field", "val").build())
+      .set("object-to-map", ImmutableMap.builder().put("key", "value").build())
+      .set("binary", "binary data".getBytes())
+      .set("boolean", false)
+      .setTimestamp("date", DATE_TIME)
+      .set("long", Long.MIN_VALUE)
+      .setDecimal("decimal", new BigDecimal("987654321.1234567890"))
+      .setDate("date-field", DATE_TIME.toLocalDate())
+      .set("float", Float.MIN_VALUE)
+      .setTime("time", DATE_TIME.toLocalTime())
+      .set("enum", "first")
+      .set("union", StructuredRecord.builder(NESTED_SCHEMA).set("inner_field", "val").build())
+      .build(),
+
+    StructuredRecord.builder(ALL_SINK_DATATYPES_SCHEMA)
+      .set("_id", "5d079ee6d078c94008e4bb47")
+      .set("string", "AAPL")
+      .set("int32", 10)
+      .set("double", 23.23)
+      .set("array", Arrays.asList("a1", "a2"))
+      .set("object", StructuredRecord.builder(NESTED_SCHEMA).set("inner_field", "val").build())
+      .set("object-to-map", ImmutableMap.builder().put("key", "value").build())
+      .set("binary", "binary data".getBytes())
+      .set("boolean", false)
+      .setTimestamp("date", DATE_TIME)
+      .set("long", Long.MAX_VALUE)
+      .setDecimal("decimal", new BigDecimal("0.1234567890"))
+      .setDate("date-field", DATE_TIME.toLocalDate())
+      .set("float", Float.MIN_VALUE)
+      .setTime("time", DATE_TIME.toLocalTime())
+      .set("enum", "second")
+      .set("union", "string")
+      .build()
+  );
+
+  private static final BiConsumer<StructuredRecord, BsonDocument> COMPARE_COMMON = (expected, actual) -> {
+    Assert.assertEquals(expected.get("string"), actual.getString("string").getValue());
+    Assert.assertEquals((int) expected.get("int32"), actual.getInt32("int32").getValue());
+    Assert.assertEquals(expected.<Double>get("double"), actual.getDouble("double").getValue(), 0.00001);
+    Assert.assertArrayEquals(expected.get("binary"), actual.getBinary("binary").getData());
+    Assert.assertEquals((long) expected.get("long"), actual.getInt64("long").getValue());
+    Assert.assertEquals(expected.get("boolean"), actual.getBoolean("boolean").getValue());
+
+    Assert.assertEquals(expected.get("array"),
+                        actual.getArray("array").getValues().stream()
+                          .map(BsonValue::asString)
+                          .map(BsonString::getValue)
+                          .collect(Collectors.toList()));
+
+    Assert.assertEquals(expected.<StructuredRecord>get("object").get("inner_field"),
+                        actual.getDocument("object").getString("inner_field").getValue());
+
+    Map<String, String> actualMap = actual.getDocument("object-to-map").entrySet().stream()
+      .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().asString().getValue()));
+
+    Assert.assertEquals(expected.get("object-to-map"), actualMap);
+
+    Assert.assertEquals(expected.getTimestamp("date").toInstant().toEpochMilli(),
+                        actual.getDateTime("date").getValue());
+
+    Assert.assertEquals(expected.getDecimal("decimal"),
+                        actual.getDecimal128("decimal").getValue().bigDecimalValue());
+  };
+
+  private static final BiConsumer<StructuredRecord, BsonDocument> COMPARE_SINK_DATA_TYPES = (expected, actual) -> {
+    Assert.assertEquals(expected.getDate("date-field").atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli(),
+                        actual.getDateTime("date-field").getValue());
+    Assert.assertEquals(expected.<Float>get("float"), actual.getDouble("float").getValue(), 0.00001);
+    Assert.assertEquals(expected.get("enum"), actual.getString("enum").getValue());
+    Assert.assertEquals(expected.getTime("time").toString(), actual.getString("time").getValue());
+    // If actual value is a record
+    if (expected.get("union") instanceof StructuredRecord) {
+      Assert.assertEquals(expected.<StructuredRecord>get("union").get("inner_field"),
+                          actual.getDocument("union").getString("inner_field").getValue());
+    }
+    // If actual value is a string
+    if (expected.get("union") instanceof String) {
+      Assert.assertEquals(expected.get("union"), actual.getString("union").getValue());
+    }
+  };
 
   private static final MongodStarter starter = MongodStarter.getDefaultInstance();
   private MongodExecutable mongodExecutable;
@@ -225,16 +338,11 @@ public class MongoDBTest extends HydratorTestBase {
     MongoDatabase mongoDatabase = mongoClient.getDatabase(MONGO_DB);
     MongoIterable<String> collections = mongoDatabase.listCollectionNames();
     Assert.assertFalse(collections.iterator().hasNext());
-    mongoDatabase.createCollection(MONGO_SOURCE_COLLECTIONS);
     MongoDatabase db = mongoClient.getDatabase(MONGO_DB);
-    MongoCollection dbCollection = db.getCollection(MONGO_SOURCE_COLLECTIONS, BsonDocument.class);
-    dbCollection.insertMany(TEST_DOCUMENTS);
 
-    // Prepare supported data types
-    mongoDatabase.createCollection(MONGO_SUPPORTED_DATA_TYPES_COLLECTIONS);
-    MongoCollection allDataTypesCollection = db.getCollection(MONGO_SUPPORTED_DATA_TYPES_COLLECTIONS,
-                                                              BsonDocument.class);
-    allDataTypesCollection.insertMany(SUPPORTED_DATA_TYPES_TEST_DOCUMENTS);
+    mongoDatabase.createCollection(SOURCE_COLLECTIONS);
+    MongoCollection allDataTypesCollection = db.getCollection(SOURCE_COLLECTIONS, BsonDocument.class);
+    allDataTypesCollection.insertMany(TEST_DOCUMENTS);
   }
 
   @After
@@ -257,18 +365,18 @@ public class MongoDBTest extends HydratorTestBase {
       "MongoDB",
       BatchSink.PLUGIN_TYPE,
       new ImmutableMap.Builder<String, String>()
-        .put(MongoDBBatchSink.Properties.CONNECTION_STRING,
-             String.format("mongodb://localhost:%d/%s.%s",
-                           mongoPort, MONGO_DB, MONGO_SINK_COLLECTIONS))
+        .putAll(getCommonPluginProperties())
+        .put(MongoDBConstants.ID_FIELD, "_id")
+        .put(MongoDBConstants.COLLECTION, MONGO_SINK_COLLECTIONS)
         .put(Constants.Reference.REFERENCE_NAME, "MongoTestDBSink1").build(),
       null));
     ETLStage sink2 = new ETLStage("MongoDB2", new ETLPlugin(
       "MongoDB",
       BatchSink.PLUGIN_TYPE,
       new ImmutableMap.Builder<String, String>()
-        .put(MongoDBBatchSink.Properties.CONNECTION_STRING,
-             String.format("mongodb://localhost:%d/%s.%s",
-                           mongoPort, MONGO_DB, secondCollectionName))
+        .putAll(getCommonPluginProperties())
+        .put(MongoDBConstants.ID_FIELD, "_id")
+        .put(MongoDBConstants.COLLECTION, secondCollectionName)
         .put(Constants.Reference.REFERENCE_NAME, "MongoTestDBSink2").build(),
       null));
     ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")
@@ -282,19 +390,18 @@ public class MongoDBTest extends HydratorTestBase {
     ApplicationId appId = NamespaceId.DEFAULT.app("MongoSinkTest");
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
-    List<StructuredRecord> inputRecords = ImmutableList.of(
-      StructuredRecord.builder(SINK_BODY_SCHEMA).set("ticker", "AAPL").set("num", 10).set("price", 500.32).build(),
-      StructuredRecord.builder(SINK_BODY_SCHEMA).set("ticker", "CDAP").set("num", 13).set("price", 212.36).build()
-    );
+
     DataSetManager<Table> inputManager = getDataset(inputDatasetName);
-    MockSource.writeInput(inputManager, inputRecords);
+    MockSource.writeInput(inputManager, ALL_SINK_DATATYPES_RECORDS);
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
     workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
-    verifyMongoSinkData(MONGO_SINK_COLLECTIONS);
-    verifyMongoSinkData(secondCollectionName);
+    verifyMongoSinkData(MONGO_SINK_COLLECTIONS, ALL_SINK_DATATYPES_RECORDS,
+                        Arrays.asList(COMPARE_COMMON, COMPARE_SINK_DATA_TYPES));
+    verifyMongoSinkData(secondCollectionName, ALL_SINK_DATATYPES_RECORDS,
+                        Arrays.asList(COMPARE_COMMON, COMPARE_SINK_DATA_TYPES));
   }
 
   @Test
@@ -304,8 +411,8 @@ public class MongoDBTest extends HydratorTestBase {
       BatchSource.PLUGIN_TYPE,
       new ImmutableMap.Builder<String, String>()
         .putAll(getCommonPluginProperties())
-        .put(MongoDBConstants.COLLECTION, MONGO_SOURCE_COLLECTIONS)
-        .put(MongoDBConstants.SCHEMA, SOURCE_BODY_SCHEMA.toString())
+        .put(MongoDBConstants.COLLECTION, SOURCE_COLLECTIONS)
+        .put(MongoDBConstants.SCHEMA, SCHEMA.toString())
         .put(Constants.Reference.REFERENCE_NAME, "MongoMongoTest").build(),
       null));
 
@@ -313,9 +420,9 @@ public class MongoDBTest extends HydratorTestBase {
       "MongoDB",
       BatchSink.PLUGIN_TYPE,
       new ImmutableMap.Builder<String, String>()
-        .put(MongoDBBatchSink.Properties.CONNECTION_STRING,
-             String.format("mongodb://localhost:%d/%s.%s",
-                           mongoPort, MONGO_DB, MONGO_SINK_COLLECTIONS))
+        .putAll(getCommonPluginProperties())
+        .put(MongoDBConstants.ID_FIELD, "_id")
+        .put(MongoDBConstants.COLLECTION, MONGO_SINK_COLLECTIONS)
         .put(Constants.Reference.REFERENCE_NAME, "MongoToMongoTest").build(),
       null));
     ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")
@@ -332,67 +439,7 @@ public class MongoDBTest extends HydratorTestBase {
     workflowManager.start();
     workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
-    MongoDatabase mongoDatabase = mongoClient.getDatabase(MONGO_DB);
-    MongoCollection<Document> documents = mongoDatabase.getCollection(MONGO_SINK_COLLECTIONS);
-    Assert.assertEquals(2, documents.count());
-    Iterable<Document> docs = documents.find(new BasicDBObject("ticker", "AAPL"));
-    Assert.assertTrue(docs.iterator().hasNext());
-    for (Document document : docs) {
-      Assert.assertEquals(10, (int) document.getInteger("num"));
-      Assert.assertEquals(23.23, document.getDouble("price"), 0.0001);
-      Assert.assertNotNull(document.get("agents"));
-    }
-
-    docs = documents.find(new BasicDBObject("ticker", "ORCL"));
-    Assert.assertTrue(docs.iterator().hasNext());
-    for (Document document : docs) {
-      Assert.assertEquals(12, (int) document.getInteger("num"));
-      Assert.assertEquals(10.10, document.getDouble("price"), 0.0001);
-      Assert.assertNotNull(document.get("agents"));
-    }
-  }
-
-  @SuppressWarnings("ConstantConditions")
-  @Test
-  public void testMongoDBSource() throws Exception {
-    ETLStage source = new ETLStage("MongoDB", new ETLPlugin(
-      "MongoDB",
-      BatchSource.PLUGIN_TYPE,
-      new ImmutableMap.Builder<String, String>()
-        .putAll(getCommonPluginProperties())
-        .put(MongoDBConstants.COLLECTION, MONGO_SOURCE_COLLECTIONS)
-        .put(MongoDBConstants.SCHEMA, SOURCE_BODY_SCHEMA.toString())
-        .put(Constants.Reference.REFERENCE_NAME, "SimpleMongoTest").build(),
-      null));
-    String outputDatasetName = "output-batchsourcetest";
-    ETLStage sink = new ETLStage("sink", MockSink.getPlugin(outputDatasetName));
-    ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")
-      .addStage(source)
-      .addStage(sink)
-      .addConnection(source.getName(), sink.getName())
-      .build();
-
-    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
-    ApplicationId appId = NamespaceId.DEFAULT.app("MongoSourceTest");
-    ApplicationManager appManager = deployApplication(appId, appRequest);
-
-    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
-    workflowManager.start();
-    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
-
-    DataSetManager<Table> outputManager = getDataset(outputDatasetName);
-    List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager);
-    Assert.assertEquals(2, outputRecords.size());
-    String ticker = outputRecords.get(0).get("ticker");
-    StructuredRecord row1 = "AAPL".equals(ticker) ? outputRecords.get(0) : outputRecords.get(1);
-    StructuredRecord row2 = "AAPL".equals(ticker) ? outputRecords.get(1) : outputRecords.get(0);
-
-    Assert.assertEquals("AAPL", row1.get("ticker"));
-    Assert.assertEquals(10, (int) row1.get("num"));
-    Assert.assertEquals(23.23, (double) row1.get("price"), 0.00001);
-    Assert.assertEquals("ORCL", row2.get("ticker"));
-    Assert.assertEquals(12, (int) row2.get("num"));
-    Assert.assertEquals(10.10, (double) row2.get("price"), 0.00001);
+    verifyMongoSinkData(MONGO_SINK_COLLECTIONS, TEST_RECORDS, Collections.singletonList(COMPARE_COMMON));
   }
 
   @SuppressWarnings("ConstantConditions")
@@ -403,8 +450,8 @@ public class MongoDBTest extends HydratorTestBase {
       BatchSource.PLUGIN_TYPE,
       new ImmutableMap.Builder<String, String>()
         .putAll(getCommonPluginProperties())
-        .put(MongoDBConstants.COLLECTION, MONGO_SUPPORTED_DATA_TYPES_COLLECTIONS)
-        .put(MongoDBConstants.SCHEMA, SUPPORTED_DATA_TYPES_SCHEMA.toString())
+        .put(MongoDBConstants.COLLECTION, SOURCE_COLLECTIONS)
+        .put(MongoDBConstants.SCHEMA, SCHEMA.toString())
         .put(Constants.Reference.REFERENCE_NAME, "AllDataTypesMongoTest").build(),
       null));
     String outputDatasetName = "all-data-types-output-batchsourcetest";
@@ -426,7 +473,7 @@ public class MongoDBTest extends HydratorTestBase {
     DataSetManager<Table> outputManager = getDataset(outputDatasetName);
     List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager);
     Assert.assertEquals(2, outputRecords.size());
-    for (BsonDocument expected : SUPPORTED_DATA_TYPES_TEST_DOCUMENTS) {
+    for (BsonDocument expected : TEST_DOCUMENTS) {
       Optional<StructuredRecord> actualOptional = outputRecords.stream()
         .filter(r -> expected.getObjectId("_id").getValue().toHexString().equals(r.get("_id")))
         .findAny();
@@ -465,22 +512,19 @@ public class MongoDBTest extends HydratorTestBase {
     }
   }
 
-  private void verifyMongoSinkData(String collectionName) throws Exception {
+  private void verifyMongoSinkData(String collectionName, List<StructuredRecord> expectedRecords,
+                                   List<BiConsumer<StructuredRecord, BsonDocument>> testActions) throws Exception {
     MongoDatabase mongoDatabase = mongoClient.getDatabase(MONGO_DB);
-    MongoCollection<Document> documents = mongoDatabase.getCollection(collectionName);
-    Assert.assertEquals(2, documents.count());
-    Iterable<Document> docs = documents.find(new BasicDBObject("ticker", "AAPL"));
-    Assert.assertTrue(docs.iterator().hasNext());
-    for (Document document : docs) {
-      Assert.assertEquals(10, (int) document.getInteger("num"));
-      Assert.assertEquals(500.32, document.getDouble("price"), 0.0001);
-    }
+    MongoCollection<BsonDocument> documents = mongoDatabase.getCollection(collectionName, BsonDocument.class);
+    Assert.assertEquals(expectedRecords.size(), documents.count());
 
-    docs = documents.find(new BasicDBObject("ticker", "CDAP"));
-    Assert.assertTrue(docs.iterator().hasNext());
-    for (Document document : docs) {
-      Assert.assertEquals(13, (int) document.getInteger("num"));
-      Assert.assertEquals(212.36, document.getDouble("price"), 0.0001);
+    for (StructuredRecord expected : expectedRecords) {
+      BsonObjectId expectedId = new BsonObjectId(new ObjectId(expected.<String>get("_id")));
+      Iterator<BsonDocument> actualIterator = documents.find(new BsonDocument("_id", expectedId)).iterator();
+      Assert.assertTrue(actualIterator.hasNext());
+      BsonDocument actual = actualIterator.next();
+      // Perform supplied test actions
+      testActions.forEach(test -> test.accept(expected, actual));
     }
   }
 

--- a/src/test/java/io/cdap/plugin/batch/sink/MongoDBBatchSinkTest.java
+++ b/src/test/java/io/cdap/plugin/batch/sink/MongoDBBatchSinkTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.batch.sink;
+
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.etl.api.validation.InvalidStageException;
+import io.cdap.cdap.etl.mock.common.MockPipelineConfigurer;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * {@link MongoDBBatchSink} test.
+ */
+public class MongoDBBatchSinkTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  private static final MongoDBBatchSink.MongoDBSinkConfig VALID_CONFIG = MongoDBSinkConfigBuilder.builder()
+    .setReferenceName("MongoDBSink")
+    .setHost("localhost")
+    .setPort(27017)
+    .setDatabase("admin")
+    .setCollection("analytics")
+    .setUser("admin")
+    .setPassword("password")
+    .setConnectionArguments("key=value;")
+    .build();
+
+  private static final MongoDBBatchSink SINK = new MongoDBBatchSink(VALID_CONFIG);
+
+  @Test
+  public void testInvalidInputSchema() {
+    Schema schema = Schema.recordOf("schema", Schema.Field.of("_id", Schema.of(Schema.Type.NULL)));
+
+    thrown.expect(InvalidStageException.class);
+    SINK.configurePipeline(new MockPipelineConfigurer(schema));
+  }
+
+  @Test
+  public void testInvalidRecordInputSchema() {
+    Schema nestedRecord = Schema.recordOf("nested", Schema.Field.of("invalid", Schema.of(Schema.Type.NULL)));
+    Schema schema = Schema.recordOf("schema", Schema.Field.of("nested", nestedRecord));
+
+    thrown.expect(InvalidStageException.class);
+    SINK.configurePipeline(new MockPipelineConfigurer(schema));
+  }
+
+  @Test
+  public void testNullableMapKeyInputSchema() {
+    Schema mapSchema = Schema.mapOf(Schema.nullableOf(Schema.of(Schema.Type.STRING)), Schema.of(Schema.Type.STRING));
+    Schema schema = Schema.recordOf("schema", Schema.Field.of("map", mapSchema));
+
+    thrown.expect(InvalidStageException.class);
+    SINK.configurePipeline(new MockPipelineConfigurer(schema));
+  }
+
+  @Test
+  public void testInvalidMapKeyInputSchema() {
+    Schema mapSchema = Schema.mapOf(Schema.of(Schema.Type.NULL), Schema.of(Schema.Type.STRING));
+    Schema schema = Schema.recordOf("schema", Schema.Field.of("map", mapSchema));
+
+    thrown.expect(InvalidStageException.class);
+    SINK.configurePipeline(new MockPipelineConfigurer(schema));
+  }
+
+  @Test
+  public void testInvalidMapValueInputSchema() {
+    Schema mapSchema = Schema.mapOf(Schema.of(Schema.Type.STRING), Schema.of(Schema.Type.NULL));
+    Schema schema = Schema.recordOf("schema", Schema.Field.of("map", mapSchema));
+
+    thrown.expect(InvalidStageException.class);
+    SINK.configurePipeline(new MockPipelineConfigurer(schema));
+  }
+
+  @Test
+  public void testInvalidArrayInputSchema() {
+    Schema schema = Schema.recordOf("schema", Schema.Field.of("array", Schema.arrayOf(Schema.of(Schema.Type.NULL))));
+
+    thrown.expect(InvalidStageException.class);
+    SINK.configurePipeline(new MockPipelineConfigurer(schema));
+  }
+
+  @Test
+  public void testIdFieldIsNotInTheSchema() {
+    Schema schema = Schema.recordOf("schema", Schema.Field.of("name", Schema.of(Schema.Type.STRING)));
+    MongoDBBatchSink.MongoDBSinkConfig config = MongoDBSinkConfigBuilder.builder(VALID_CONFIG)
+      .setIdField("not_in_the_schema")
+      .build();
+    MongoDBBatchSink sink = new MongoDBBatchSink(config);
+
+    thrown.expect(InvalidStageException.class);
+    sink.configurePipeline(new MockPipelineConfigurer(schema));
+  }
+
+  @Test
+  public void testIdFieldConflictsWithDefaultId() {
+    Schema schema = Schema.recordOf("schema",
+                                    Schema.Field.of("_id", Schema.of(Schema.Type.STRING)),
+                                    Schema.Field.of("name", Schema.of(Schema.Type.STRING)));
+    MongoDBBatchSink.MongoDBSinkConfig config = MongoDBSinkConfigBuilder.builder(VALID_CONFIG)
+      .setIdField("name")
+      .build();
+    MongoDBBatchSink sink = new MongoDBBatchSink(config);
+
+    thrown.expect(InvalidStageException.class);
+    sink.configurePipeline(new MockPipelineConfigurer(schema));
+  }
+}

--- a/src/test/java/io/cdap/plugin/batch/sink/MongoDBSinkConfigBuilder.java
+++ b/src/test/java/io/cdap/plugin/batch/sink/MongoDBSinkConfigBuilder.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.batch.sink;
+
+import io.cdap.plugin.batch.MongoDBConfigBuilder;
+import io.cdap.plugin.batch.source.MongoDBBatchSource;
+
+/**
+ * Builder class that provides handy methods to construct {@link MongoDBBatchSource.MongoDBSourceConfig} for testing.
+ */
+public class MongoDBSinkConfigBuilder extends MongoDBConfigBuilder<MongoDBSinkConfigBuilder> {
+
+  private String idField;
+
+  public static MongoDBSinkConfigBuilder builder() {
+    return new MongoDBSinkConfigBuilder();
+  }
+
+  public static MongoDBSinkConfigBuilder builder(MongoDBBatchSink.MongoDBSinkConfig original) {
+    return builder()
+      .setReferenceName(original.getReferenceName())
+      .setHost(original.getHost())
+      .setPort(original.getPort())
+      .setDatabase(original.getDatabase())
+      .setCollection(original.getCollection())
+      .setUser(original.getUser())
+      .setPassword(original.getPassword())
+      .setConnectionArguments(original.getConnectionArguments())
+      .setIdField(original.getIdField());
+  }
+
+  public MongoDBSinkConfigBuilder setIdField(String idField) {
+    this.idField = idField;
+    return this;
+  }
+
+  public MongoDBBatchSink.MongoDBSinkConfig build() {
+    return new MongoDBBatchSink.MongoDBSinkConfig(referenceName, host, port, database, collection, user, password,
+                                                  connectionArguments, idField);
+  }
+}

--- a/src/test/java/io/cdap/plugin/batch/sink/RecordToBSONWritableTransformerTest.java
+++ b/src/test/java/io/cdap/plugin/batch/sink/RecordToBSONWritableTransformerTest.java
@@ -1,0 +1,633 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.batch.sink;
+
+import com.google.common.collect.ImmutableMap;
+import com.mongodb.hadoop.io.BSONWritable;
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.format.UnexpectedFormatException;
+import io.cdap.cdap.api.data.schema.Schema;
+import org.bson.BSONObject;
+import org.bson.BsonDocument;
+import org.bson.types.ObjectId;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * {@link RecordToBSONWritableTransformer} test.
+ */
+public class RecordToBSONWritableTransformerTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  private static final RecordToBSONWritableTransformer TRANSFORMER = new RecordToBSONWritableTransformer();
+
+  @Test
+  public void testTransform() {
+    Schema schema = Schema.recordOf("schema",
+                                    Schema.Field.of("int_field", Schema.nullableOf(Schema.of(Schema.Type.INT))),
+                                    Schema.Field.of("long_field", Schema.nullableOf(Schema.of(Schema.Type.LONG))),
+                                    Schema.Field.of("double_field", Schema.nullableOf(Schema.of(Schema.Type.DOUBLE))),
+                                    Schema.Field.of("float_field", Schema.nullableOf(Schema.of(Schema.Type.FLOAT))),
+                                    Schema.Field.of("string_field", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+                                    Schema.Field.of("boolean_field", Schema.nullableOf(Schema.of(Schema.Type.BOOLEAN))),
+                                    Schema.Field.of("bytes_field", Schema.nullableOf(Schema.of(Schema.Type.BYTES))),
+                                    Schema.Field.of("null_field", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+                                    Schema.Field.of("array_field",
+                                                    Schema.arrayOf(Schema.nullableOf(Schema.of(Schema.Type.LONG)))));
+
+    StructuredRecord inputRecord = StructuredRecord.builder(schema)
+      .set("int_field", 15)
+      .set("long_field", 10L)
+      .set("double_field", 10.5D)
+      .set("float_field", 15.5F)
+      .set("string_field", "string_value")
+      .set("boolean_field", true)
+      .set("bytes_field", "test_blob".getBytes())
+      .set("null_field", null)
+      .set("array_field", Arrays.asList(1L, null, 2L, null, 3L))
+      .build();
+
+    BSONWritable bsonWritable = TRANSFORMER.transform(inputRecord);
+    BSONObject bsonObject = bsonWritable.getDoc();
+
+    Assert.assertEquals(inputRecord.get("int_field"), bsonObject.get("int_field"));
+    Assert.assertEquals(inputRecord.get("long_field"), bsonObject.get("long_field"));
+    Assert.assertEquals(inputRecord.get("double_field"), bsonObject.get("double_field"));
+    Assert.assertEquals(inputRecord.get("float_field"), bsonObject.get("float_field"));
+    Assert.assertEquals(inputRecord.get("string_field"), bsonObject.get("string_field"));
+    Assert.assertEquals(inputRecord.get("boolean_field"), bsonObject.get("boolean_field"));
+    Assert.assertEquals(inputRecord.get("bytes_field"), bsonObject.get("bytes_field"));
+    Assert.assertNull(bsonObject.get("null_field"));
+    Assert.assertEquals(inputRecord.get("array_field"), bsonObject.get("array_field"));
+  }
+
+  @Test
+  public void testTransformNestedMapsSimpleTypes() {
+    Schema schema = Schema.recordOf("schema",
+                                    Schema.Field.of("nested_string_maps", Schema.mapOf(
+                                      Schema.of(Schema.Type.STRING), Schema.mapOf(Schema.of(Schema.Type.STRING),
+                                                                                  Schema.of(Schema.Type.STRING)))),
+                                    Schema.Field.of("nested_int_maps", Schema.mapOf(
+                                      Schema.of(Schema.Type.STRING), Schema.mapOf(Schema.of(Schema.Type.STRING),
+                                                                                  Schema.of(Schema.Type.INT)))),
+                                    Schema.Field.of("nested_bytes_maps", Schema.mapOf(
+                                      Schema.of(Schema.Type.STRING), Schema.mapOf(Schema.of(Schema.Type.STRING),
+                                                                                  Schema.of(Schema.Type.BYTES))))
+    );
+
+    Map<String, Map<String, String>> stringMap = ImmutableMap.<String, Map<String, String>>builder()
+      .put("nested_map1", ImmutableMap.<String, String>builder().put("k1", "v1").build())
+      .put("nested_map2", ImmutableMap.<String, String>builder().put("k2", "v2").build())
+      .put("nested_map3", ImmutableMap.<String, String>builder().put("k3", "v3").build())
+      .build();
+
+    Map<String, Map<String, Integer>> intMap = ImmutableMap.<String, Map<String, Integer>>builder()
+      .put("nested_map1", ImmutableMap.<String, Integer>builder().put("k1", 1).build())
+      .put("nested_map2", ImmutableMap.<String, Integer>builder().put("k2", 2).build())
+      .put("nested_map3", ImmutableMap.<String, Integer>builder().put("k3", 3).build())
+      .build();
+
+    Map<String, Map<String, byte[]>> bytesMap = ImmutableMap.<String, Map<String, byte[]>>builder()
+      .put("nested_map1", ImmutableMap.<String, byte[]>builder().put("k1", "v1".getBytes()).build())
+      .put("nested_map2", ImmutableMap.<String, byte[]>builder().put("k2", "v2".getBytes()).build())
+      .put("nested_map3", ImmutableMap.<String, byte[]>builder().put("k3", "v3".getBytes()).build())
+      .build();
+
+    StructuredRecord inputRecord = StructuredRecord.builder(schema)
+      .set("nested_string_maps", stringMap)
+      .set("nested_int_maps", intMap)
+      .set("nested_bytes_maps", bytesMap)
+      .build();
+
+    BSONWritable bsonWritable = TRANSFORMER.transform(inputRecord);
+    BSONObject bsonObject = bsonWritable.getDoc();
+
+    Assert.assertEquals(inputRecord.get("nested_string_maps"), bsonObject.get("nested_string_maps"));
+    Assert.assertEquals(inputRecord.get("nested_int_maps"), bsonObject.get("nested_int_maps"));
+    Assert.assertEquals(inputRecord.get("nested_bytes_maps"), bsonObject.get("nested_bytes_maps"));
+  }
+
+  @Test
+  public void testTransformComplexNestedMaps() {
+
+    Schema nestedRecordSchema = Schema.recordOf("nested_object",
+                                                Schema.Field.of("nested_string_field", Schema.of(Schema.Type.STRING)),
+                                                Schema.Field.of("nested_decimal_field", Schema.decimalOf(4, 2)));
+
+    Schema schema = Schema.recordOf("schema",
+                                    Schema.Field.of("map_field", Schema.nullableOf(
+                                      Schema.mapOf(Schema.of(Schema.Type.STRING),
+                                                   Schema.mapOf(Schema.of(Schema.Type.STRING), nestedRecordSchema)))));
+
+    StructuredRecord nestedRecord1 = StructuredRecord.builder(nestedRecordSchema)
+      .set("nested_string_field", "some value")
+      .setDecimal("nested_decimal_field", new BigDecimal("12.34"))
+      .build();
+
+    StructuredRecord nestedRecord2 = StructuredRecord.builder(nestedRecordSchema)
+      .set("nested_string_field", "some value")
+      .setDecimal("nested_decimal_field", new BigDecimal("10.00"))
+      .build();
+
+    StructuredRecord nestedRecord3 = StructuredRecord.builder(nestedRecordSchema)
+      .set("nested_string_field", "some value")
+      .setDecimal("nested_decimal_field", new BigDecimal("10.01"))
+      .build();
+
+    Map<String, Map<String, StructuredRecord>> map = ImmutableMap.<String, Map<String, StructuredRecord>>builder()
+      .put("nested_map1", ImmutableMap.<String, StructuredRecord>builder().put("k1", nestedRecord1).build())
+      .put("nested_map2", ImmutableMap.<String, StructuredRecord>builder().put("k2", nestedRecord2).build())
+      .put("nested_map3", ImmutableMap.<String, StructuredRecord>builder().put("k3", nestedRecord3).build())
+      .build();
+
+    StructuredRecord inputRecord = StructuredRecord.builder(schema)
+      .set("map_field", map)
+      .build();
+
+    BSONWritable bsonWritable = TRANSFORMER.transform(inputRecord);
+    BSONObject bsonObject = bsonWritable.getDoc();
+
+    // Nested records must be transformed to a BSONObject as a regular ones
+    BSONObject actualNestedMap1 = (BSONObject) ((BSONObject) bsonObject.get("map_field")).get("nested_map1");
+    Assert.assertEquals(TRANSFORMER.transform(nestedRecord1).getDoc(), actualNestedMap1.get("k1"));
+
+    BSONObject actualNestedMap2 = (BSONObject) ((BSONObject) bsonObject.get("map_field")).get("nested_map2");
+    Assert.assertEquals(TRANSFORMER.transform(nestedRecord2).getDoc(), actualNestedMap2.get("k2"));
+
+    BSONObject actualNestedMap3 = (BSONObject) ((BSONObject) bsonObject.get("map_field")).get("nested_map3");
+    Assert.assertEquals(TRANSFORMER.transform(nestedRecord3).getDoc(), actualNestedMap3.get("k3"));
+  }
+
+  @Test
+  public void testTransformNestedArraysSimpleTypes() {
+    Schema schema = Schema.recordOf("schema",
+                                    Schema.Field.of("nested_string_array", Schema.arrayOf(
+                                      Schema.arrayOf(Schema.of(Schema.Type.STRING)))),
+                                    Schema.Field.of("nested_int_array", Schema.arrayOf(
+                                      Schema.arrayOf(Schema.of(Schema.Type.INT)))),
+                                    Schema.Field.of("nested_bytes_array", Schema.arrayOf(
+                                      Schema.arrayOf(Schema.of(Schema.Type.BYTES))))
+    );
+
+    List<List<String>> stringArray = Arrays.asList(
+      Arrays.asList("1", "2", "3"),
+      Arrays.asList("1", "2", "3"),
+      Arrays.asList("1", "2", "3")
+    );
+
+    List<List<Integer>> intArray = Arrays.asList(
+      Arrays.asList(1, 2, 3),
+      Arrays.asList(1, 2, 3),
+      Arrays.asList(1, 2, 3)
+    );
+
+    List<List<byte[]>> bytesArray = Arrays.asList(
+      Arrays.asList("1".getBytes(), "2".getBytes(), "3".getBytes()),
+      Arrays.asList("1".getBytes(), "2".getBytes(), "3".getBytes()),
+      Arrays.asList("1".getBytes(), "2".getBytes(), "3".getBytes())
+    );
+
+    StructuredRecord inputRecord = StructuredRecord.builder(schema)
+      .set("nested_string_array", stringArray)
+      .set("nested_int_array", intArray)
+      .set("nested_bytes_array", bytesArray)
+      .build();
+
+    BSONWritable bsonWritable = TRANSFORMER.transform(inputRecord);
+    BSONObject bsonObject = bsonWritable.getDoc();
+
+    Assert.assertEquals(inputRecord.get("nested_string_array"), bsonObject.get("nested_string_array"));
+    Assert.assertEquals(inputRecord.get("nested_int_array"), bsonObject.get("nested_int_array"));
+    Assert.assertEquals(inputRecord.get("nested_bytes_array"), bsonObject.get("nested_bytes_array"));
+  }
+
+  @Test
+  public void testTransformComplexNestedArrays() {
+
+    Schema nestedRecordSchema = Schema.recordOf("nested_object",
+                                                Schema.Field.of("nested_string_field", Schema.of(Schema.Type.STRING)),
+                                                Schema.Field.of("nested_decimal_field", Schema.decimalOf(4, 2)));
+    Schema schema = Schema.recordOf("schema",
+                                    Schema.Field.of("nested_array_of_maps", Schema.arrayOf(
+                                      Schema.arrayOf(Schema.mapOf(Schema.of(Schema.Type.STRING),
+                                                                  Schema.of(Schema.Type.STRING))))),
+                                    Schema.Field.of("nested_array_of_records", Schema.arrayOf(
+                                      Schema.arrayOf(nestedRecordSchema)))
+    );
+
+    List<List<Map<String, String>>> arrayOfMaps = Arrays.asList(
+      Collections.singletonList(ImmutableMap.<String, String>builder().put("k1", "v1").build()),
+      Collections.singletonList(ImmutableMap.<String, String>builder().put("k2", "v2").build()),
+      Collections.singletonList(ImmutableMap.<String, String>builder().put("k3", "v3").build())
+    );
+
+    List<List<StructuredRecord>> arrayOfRecords = Arrays.asList(
+      Collections.singletonList(
+        StructuredRecord.builder(nestedRecordSchema)
+          .set("nested_string_field", "some value")
+          .setDecimal("nested_decimal_field", new BigDecimal("12.34"))
+          .build()
+      ),
+
+      Collections.singletonList(
+        StructuredRecord.builder(nestedRecordSchema)
+          .set("nested_string_field", "some value")
+          .setDecimal("nested_decimal_field", new BigDecimal("10.00"))
+          .build()
+      ),
+
+      Collections.singletonList(
+        StructuredRecord.builder(nestedRecordSchema)
+          .set("nested_string_field", "some value")
+          .setDecimal("nested_decimal_field", new BigDecimal("10.01"))
+          .build()
+      )
+    );
+
+    StructuredRecord inputRecord = StructuredRecord.builder(schema)
+      .set("nested_array_of_maps", arrayOfMaps)
+      .set("nested_array_of_records", arrayOfRecords)
+      .build();
+
+    BSONWritable bsonWritable = TRANSFORMER.transform(inputRecord);
+    BSONObject bsonObject = bsonWritable.getDoc();
+
+    Assert.assertEquals(inputRecord.get("nested_array_of_maps"), bsonObject.get("nested_array_of_maps"));
+
+    // Nested records must be transformed to a BSONObject as a regular ones
+    List actualArrayOfRecords = (List) bsonObject.get("nested_array_of_records");
+    Assert.assertEquals(TRANSFORMER.transform(arrayOfRecords.get(0).get(0)).getDoc(),
+                        ((List) actualArrayOfRecords.get(0)).get(0));
+
+    Assert.assertEquals(TRANSFORMER.transform(arrayOfRecords.get(1).get(0)).getDoc(),
+                        ((List) actualArrayOfRecords.get(1)).get(0));
+
+    Assert.assertEquals(TRANSFORMER.transform(arrayOfRecords.get(2).get(0)).getDoc(),
+                        ((List) actualArrayOfRecords.get(2)).get(0));
+  }
+
+  @Test
+  public void testTransformStringIdField() {
+    Schema nestedRecordSchema = Schema.recordOf("nested",
+                                                Schema.Field.of("string_field", Schema.of(Schema.Type.STRING)));
+    Schema schema = Schema.recordOf("schema",
+                                    Schema.Field.of("string_field", Schema.of(Schema.Type.STRING)),
+                                    Schema.Field.of("nested_record", nestedRecordSchema));
+
+    StructuredRecord inputRecord = StructuredRecord.builder(schema)
+      .set("string_field", "5d431557d62a513457e791f4")
+      .set("nested_record", StructuredRecord.builder(nestedRecordSchema)
+        .set("string_field", "5d431557d62a513457e791f4")
+        .build())
+      .build();
+
+    BSONWritable bsonWritable = new RecordToBSONWritableTransformer("string_field").transform(inputRecord);
+    BSONObject bsonObject = bsonWritable.getDoc();
+
+    Assert.assertEquals(new ObjectId("5d431557d62a513457e791f4"), bsonObject.get("_id"));
+    Assert.assertFalse(bsonObject.containsField("string_field"));
+
+    BSONObject nestedActual = (BSONObject) bsonObject.get("nested_record");
+    // Nested records must not be affected
+    Assert.assertFalse(nestedActual.containsField("_id"));
+  }
+
+  @Test
+  public void testTransformBytesIdField() {
+    Schema nestedRecordSchema = Schema.recordOf("nested",
+                                                Schema.Field.of("bytes_field", Schema.of(Schema.Type.STRING)));
+    Schema schema = Schema.recordOf("schema",
+                                    Schema.Field.of("bytes_field", Schema.of(Schema.Type.BYTES)),
+                                    Schema.Field.of("nested_record", nestedRecordSchema));
+
+    ByteBuffer byteBuffer = ByteBuffer.allocate(12);
+    new ObjectId("5d431557d62a513457e791f4").putToByteBuffer(byteBuffer);
+
+    StructuredRecord inputRecord = StructuredRecord.builder(schema)
+      .set("bytes_field", byteBuffer.array())
+      .set("nested_record", StructuredRecord.builder(nestedRecordSchema)
+        .set("bytes_field", "5d431557d62a513457e791f4")
+        .build())
+      .build();
+
+    BSONWritable bsonWritable = new RecordToBSONWritableTransformer("bytes_field").transform(inputRecord);
+    BSONObject bsonObject = bsonWritable.getDoc();
+
+    Assert.assertEquals(new ObjectId("5d431557d62a513457e791f4"), bsonObject.get("_id"));
+    Assert.assertFalse(bsonObject.containsField("bytes_field"));
+
+    BSONObject nestedActual = (BSONObject) bsonObject.get("nested_record");
+    // Nested records must not be affected
+    Assert.assertFalse(nestedActual.containsField("_id"));
+  }
+
+  @Test
+  public void testTransformUnionBytes() {
+    Schema schema = Schema.recordOf("schema",
+                                    Schema.Field.of("union_field", Schema.unionOf(
+                                      Schema.of(Schema.Type.STRING),
+                                      Schema.of(Schema.Type.BYTES)
+                                    )));
+
+
+    StructuredRecord inputRecord = StructuredRecord.builder(schema)
+      .set("union_field", ByteBuffer.wrap("bytes".getBytes()))
+      .build();
+
+    BSONWritable bsonWritable = TRANSFORMER.transform(inputRecord);
+    BSONObject bsonObject = bsonWritable.getDoc();
+
+    // ByteBuffer value must be transformed to byte array, since it can not be written directly via BSONWritable
+    Assert.assertTrue(bsonObject.get("union_field") instanceof byte[]);
+    Assert.assertArrayEquals("bytes".getBytes(), (byte[]) bsonObject.get("union_field"));
+  }
+
+  @Test
+  public void testTransformUnionRecord() {
+    Schema recordSchema = Schema.recordOf("nested", Schema.Field.of("bytes_field", Schema.of(Schema.Type.BYTES)));
+    Schema schema = Schema.recordOf("schema", Schema.Field.of("union_field", Schema.unionOf(
+      Schema.of(Schema.Type.STRING), recordSchema)));
+
+    StructuredRecord inputRecord = StructuredRecord.builder(schema)
+      .set("union_field", StructuredRecord.builder(recordSchema)
+        .set("bytes_field", ByteBuffer.wrap("bytes".getBytes()))
+        .build())
+      .build();
+
+    BSONWritable bsonWritable = TRANSFORMER.transform(inputRecord);
+    BSONObject bsonObject = bsonWritable.getDoc();
+
+    Assert.assertTrue(bsonObject.containsField("union_field"));
+    // Record must be transformed to BSONObject
+    Assert.assertTrue(bsonObject.get("union_field") instanceof BSONObject);
+
+    // ByteBuffer value must be transformed to byte array, since it can not be written directly via BSONWritable
+    BSONObject recordActual = (BSONObject) bsonObject.get("union_field");
+    Assert.assertTrue(recordActual.get("bytes_field") instanceof byte[]);
+    Assert.assertArrayEquals("bytes".getBytes(), (byte[]) recordActual.get("bytes_field"));
+  }
+
+  @Test
+  public void testTransformEmpty() {
+    Schema schema = Schema.recordOf("schema",
+                                    Schema.Field.of("int_field", Schema.nullableOf(Schema.of(Schema.Type.INT))),
+                                    Schema.Field.of("long_field", Schema.nullableOf(Schema.of(Schema.Type.LONG))),
+                                    Schema.Field.of("double_field", Schema.nullableOf(Schema.of(Schema.Type.DOUBLE))),
+                                    Schema.Field.of("float_field", Schema.nullableOf(Schema.of(Schema.Type.FLOAT))),
+                                    Schema.Field.of("string_field", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+                                    Schema.Field.of("boolean_field", Schema.nullableOf(Schema.of(Schema.Type.BOOLEAN))),
+                                    Schema.Field.of("bytes_field", Schema.nullableOf(Schema.of(Schema.Type.BYTES))),
+                                    Schema.Field.of("null_field", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+                                    Schema.Field.of("decimal", Schema.nullableOf(Schema.decimalOf(6, 4))),
+                                    Schema.Field.of("date", Schema.nullableOf(Schema.of(Schema.LogicalType.DATE))),
+                                    Schema.Field.of("array_field",
+                                                    Schema.nullableOf(Schema.arrayOf(Schema.of(Schema.Type.LONG)))),
+                                    Schema.Field.of("timestamp_millis",
+                                                    Schema.nullableOf(Schema.of(Schema.LogicalType.TIMESTAMP_MILLIS))),
+                                    Schema.Field.of("timestamp_micros",
+                                                    Schema.nullableOf(Schema.of(Schema.LogicalType.TIMESTAMP_MICROS))),
+                                    Schema.Field.of("time_millis",
+                                                    Schema.nullableOf(Schema.of(Schema.LogicalType.TIME_MILLIS))),
+                                    Schema.Field.of("time_micros",
+                                                    Schema.nullableOf(Schema.of(Schema.LogicalType.TIME_MILLIS)))
+    );
+
+    StructuredRecord inputRecord = StructuredRecord.builder(schema)
+      .build();
+
+    BSONWritable bsonWritable = TRANSFORMER.transform(inputRecord);
+    BSONObject bsonObject = bsonWritable.getDoc();
+
+    Assert.assertNotNull(bsonObject);
+    Assert.assertNull(inputRecord.get("int_field"));
+    Assert.assertNull(inputRecord.get("long_field"));
+    Assert.assertNull(inputRecord.get("double_field"));
+    Assert.assertNull(inputRecord.get("float_field"));
+    Assert.assertNull(inputRecord.get("string_field"));
+    Assert.assertNull(inputRecord.get("boolean_field"));
+    Assert.assertNull(inputRecord.get("bytes_field"));
+    Assert.assertNull(bsonObject.get("null_field"));
+    Assert.assertNull(inputRecord.get("array_field"));
+    Assert.assertNull(inputRecord.get("decimal"));
+    Assert.assertNull(inputRecord.get("timestamp_millis"));
+    Assert.assertNull(inputRecord.get("timestamp_micros"));
+    Assert.assertNull(inputRecord.get("time_millis"));
+    Assert.assertNull(inputRecord.get("time_micros"));
+    Assert.assertNull(inputRecord.get("date"));
+  }
+
+
+  @Test
+  public void testTransformInvalidStringIdField() {
+    Schema schema = Schema.recordOf("schema", Schema.Field.of("string_field", Schema.of(Schema.Type.STRING)));
+    StructuredRecord inputRecord = StructuredRecord.builder(schema)
+      .set("string_field", "not a valid identifier")
+      .build();
+
+    thrown.expect(UnexpectedFormatException.class);
+    new RecordToBSONWritableTransformer("string_field").transform(inputRecord);
+  }
+
+  @Test
+  public void testTransformArrays() {
+    Schema schema = Schema.recordOf("schema",
+                                    Schema.Field.of("list_field", Schema.arrayOf(Schema.of(Schema.Type.LONG))),
+                                    Schema.Field.of("set_field", Schema.arrayOf(Schema.of(Schema.Type.LONG))),
+                                    Schema.Field.of("array_field", Schema.arrayOf(Schema.of(Schema.Type.LONG))));
+
+    List<Long> expected = Arrays.asList(1L, 2L, null, 3L);
+    Set<Long> expectedSet = new HashSet<>(expected);
+    StructuredRecord inputRecord = StructuredRecord.builder(schema)
+      .set("set_field", expectedSet)
+      .set("list_field", expected)
+      .set("array_field", expected.toArray())
+      .build();
+
+    BSONWritable bsonWritable = TRANSFORMER.transform(inputRecord);
+    BSONObject bsonObject = bsonWritable.getDoc();
+    Assert.assertNotNull(bsonObject);
+    Assert.assertEquals(expectedSet, new HashSet<>((List<Long>) bsonObject.get("set_field")));
+    Assert.assertEquals(expected, bsonObject.get("list_field"));
+    Assert.assertEquals(expected, bsonObject.get("array_field"));
+  }
+
+  @Test
+  public void testTransformLogicalTypes() {
+    Schema schema = Schema.recordOf("schema",
+                                    Schema.Field.of("decimal", Schema.decimalOf(4, 2)),
+                                    Schema.Field.of("timestamp_millis", Schema.of(Schema.LogicalType.TIMESTAMP_MILLIS)),
+                                    Schema.Field.of("timestamp_micros", Schema.of(Schema.LogicalType.TIMESTAMP_MICROS)),
+                                    Schema.Field.of("time_millis", Schema.of(Schema.LogicalType.TIME_MILLIS)),
+                                    Schema.Field.of("time_micros", Schema.of(Schema.LogicalType.TIME_MICROS)),
+                                    Schema.Field.of("date", Schema.of(Schema.LogicalType.DATE)));
+
+    StructuredRecord inputRecord = StructuredRecord.builder(schema)
+      .setDecimal("decimal", new BigDecimal("10.01"))
+      .setTimestamp("timestamp_millis", ZonedDateTime.now(ZoneOffset.UTC))
+      .setTimestamp("timestamp_micros", ZonedDateTime.now(ZoneOffset.UTC))
+      .setTime("time_millis", LocalTime.now(ZoneOffset.UTC))
+      .setTime("time_micros", LocalTime.now(ZoneOffset.UTC))
+      .setDate("date", LocalDate.now(ZoneOffset.UTC))
+      .build();
+
+    BSONWritable bsonWritable = TRANSFORMER.transform(inputRecord);
+    BSONObject bsonObject = bsonWritable.getDoc();
+    Assert.assertNotNull(bsonObject);
+    BsonDocument bsonDocument = BsonDocument.parse(bsonObject.toString());
+    Assert.assertEquals(inputRecord.getDecimal("decimal"),
+                        bsonDocument.getDecimal128("decimal").getValue().bigDecimalValue());
+    Assert.assertEquals(inputRecord.getTimestamp("timestamp_millis").toInstant().toEpochMilli(),
+                        bsonDocument.getDateTime("timestamp_millis").getValue());
+    Assert.assertEquals(inputRecord.getTimestamp("timestamp_micros").toInstant().toEpochMilli(),
+                        bsonDocument.getDateTime("timestamp_micros").getValue());
+    Assert.assertEquals(inputRecord.getTime("time_millis").toString(),
+                        bsonDocument.getString("time_millis").getValue());
+    Assert.assertEquals(inputRecord.getTime("time_micros").toString(),
+                        bsonDocument.getString("time_micros").getValue());
+    Assert.assertEquals(inputRecord.getDate("date").atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                        bsonDocument.getDateTime("date").getValue());
+  }
+
+  @Test
+  public void testTransformNestedLogicalTypes() {
+    Schema schema = Schema.recordOf("schema",
+                                    Schema.Field.of("decimal_array", Schema.arrayOf(Schema.decimalOf(4, 2))),
+                                    Schema.Field.of("timestamp_millis_array",
+                                                    Schema.arrayOf(Schema.of(Schema.LogicalType.TIMESTAMP_MILLIS))),
+                                    Schema.Field.of("timestamp_micros_array",
+                                                    Schema.arrayOf(Schema.of(Schema.LogicalType.TIMESTAMP_MICROS))),
+                                    Schema.Field.of("time_millis_array",
+                                                    Schema.arrayOf(Schema.of(Schema.LogicalType.TIME_MILLIS))),
+                                    Schema.Field.of("time_micros_array",
+                                                    Schema.arrayOf(Schema.of(Schema.LogicalType.TIME_MICROS))),
+                                    Schema.Field.of("date_array",
+                                                    Schema.arrayOf(Schema.of(Schema.LogicalType.DATE)))
+    );
+
+    // Set values of logical types on temporary record to get their physical representation
+    Schema tmpSchema = Schema.recordOf("schema",
+                                       Schema.Field.of("decimal", Schema.decimalOf(4, 2)),
+                                       Schema.Field.of("timestamp_millis",
+                                                       Schema.of(Schema.LogicalType.TIMESTAMP_MILLIS)),
+                                       Schema.Field.of("timestamp_micros",
+                                                       Schema.of(Schema.LogicalType.TIMESTAMP_MICROS)),
+                                       Schema.Field.of("time_millis", Schema.of(Schema.LogicalType.TIME_MILLIS)),
+                                       Schema.Field.of("time_micros", Schema.of(Schema.LogicalType.TIME_MICROS)),
+                                       Schema.Field.of("date", Schema.of(Schema.LogicalType.DATE)));
+
+    StructuredRecord tmpRecord = StructuredRecord.builder(tmpSchema)
+      .setDecimal("decimal", new BigDecimal("10.01"))
+      .setTimestamp("timestamp_millis", ZonedDateTime.now(ZoneOffset.UTC))
+      .setTimestamp("timestamp_micros", ZonedDateTime.now(ZoneOffset.UTC))
+      .setTime("time_millis", LocalTime.now(ZoneOffset.UTC))
+      .setTime("time_micros", LocalTime.now(ZoneOffset.UTC))
+      .setDate("date", LocalDate.now(ZoneOffset.UTC))
+      .build();
+
+    StructuredRecord inputRecord = StructuredRecord.builder(schema)
+      .set("decimal_array", new byte[][]{tmpRecord.get("decimal")})
+      .set("timestamp_millis_array", Collections.singleton(tmpRecord.get("timestamp_millis")))
+      .set("timestamp_micros_array", Collections.singleton(tmpRecord.get("timestamp_micros")))
+      .set("time_millis_array", Collections.singleton(tmpRecord.get("time_millis")))
+      .set("time_micros_array", Collections.singleton(tmpRecord.get("time_micros")))
+      .set("date_array", Collections.singleton(tmpRecord.get("date")))
+      .build();
+
+    BSONWritable bsonWritable = TRANSFORMER.transform(inputRecord);
+    BSONObject bsonObject = bsonWritable.getDoc();
+    Assert.assertNotNull(bsonObject);
+    BsonDocument bsonDocument = BsonDocument.parse(bsonObject.toString());
+    Assert.assertEquals(tmpRecord.getDecimal("decimal"),
+                        bsonDocument.getArray("decimal_array").get(0).asDecimal128().getValue().bigDecimalValue());
+    Assert.assertEquals(tmpRecord.getTimestamp("timestamp_millis").toInstant().toEpochMilli(),
+                        bsonDocument.getArray("timestamp_millis_array").get(0).asDateTime().getValue());
+    Assert.assertEquals(tmpRecord.getTimestamp("timestamp_micros").toInstant().toEpochMilli(),
+                        bsonDocument.getArray("timestamp_micros_array").get(0).asDateTime().getValue());
+    Assert.assertEquals(tmpRecord.getTime("time_millis").toString(),
+                        bsonDocument.getArray("time_millis_array").get(0).asString().getValue());
+    Assert.assertEquals(tmpRecord.getTime("time_micros").toString(),
+                        bsonDocument.getArray("time_micros_array").get(0).asString().getValue());
+    Assert.assertEquals(tmpRecord.getDate("date").atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                        bsonDocument.getArray("date_array").get(0).asDateTime().getValue());
+  }
+
+  @Test
+  public void testTransformUnionLogicalTypes() {
+    Schema schema = Schema.recordOf("schema",
+                                    Schema.Field.of("decimal", Schema.unionOf(
+                                      Schema.decimalOf(4, 2),
+                                      Schema.of(Schema.LogicalType.TIMESTAMP_MILLIS))),
+                                    Schema.Field.of("timestamp_millis", Schema.unionOf(
+                                      Schema.of(Schema.LogicalType.TIMESTAMP_MILLIS),
+                                      Schema.of(Schema.LogicalType.TIME_MILLIS))),
+                                    Schema.Field.of("timestamp_micros", Schema.unionOf(
+                                      Schema.of(Schema.LogicalType.TIMESTAMP_MICROS),
+                                      Schema.of(Schema.LogicalType.TIME_MILLIS))),
+                                    Schema.Field.of("time_millis", Schema.unionOf(
+                                      Schema.of(Schema.LogicalType.TIME_MILLIS),
+                                      Schema.of(Schema.LogicalType.TIME_MICROS))),
+                                    Schema.Field.of("time_micros", Schema.unionOf(
+                                      Schema.of(Schema.LogicalType.TIME_MICROS),
+                                      Schema.of(Schema.LogicalType.TIME_MILLIS))),
+                                    Schema.Field.of("date", Schema.unionOf(
+                                      Schema.of(Schema.LogicalType.DATE),
+                                      Schema.of(Schema.LogicalType.TIME_MICROS))));
+
+    StructuredRecord inputRecord = StructuredRecord.builder(schema)
+      .setDecimal("decimal", new BigDecimal("10.01"))
+      .setTimestamp("timestamp_millis", ZonedDateTime.now(ZoneOffset.UTC))
+      .setTimestamp("timestamp_micros", ZonedDateTime.now(ZoneOffset.UTC))
+      .setTime("time_millis", LocalTime.now(ZoneOffset.UTC))
+      .setTime("time_micros", LocalTime.now(ZoneOffset.UTC))
+      .setDate("date", LocalDate.now(ZoneOffset.UTC))
+      .build();
+
+    BSONWritable bsonWritable = TRANSFORMER.transform(inputRecord);
+    BSONObject bsonObject = bsonWritable.getDoc();
+    Assert.assertNotNull(bsonObject);
+    BsonDocument bsonDocument = BsonDocument.parse(bsonObject.toString());
+    Assert.assertEquals(inputRecord.getDecimal("decimal"),
+                        bsonDocument.getDecimal128("decimal").getValue().bigDecimalValue());
+    Assert.assertEquals(inputRecord.getTimestamp("timestamp_millis").toInstant().toEpochMilli(),
+                        bsonDocument.getDateTime("timestamp_millis").getValue());
+    Assert.assertEquals(inputRecord.getTimestamp("timestamp_micros").toInstant().toEpochMilli(),
+                        bsonDocument.getDateTime("timestamp_micros").getValue());
+    Assert.assertEquals(inputRecord.getTime("time_millis").toString(),
+                        bsonDocument.getString("time_millis").getValue());
+    Assert.assertEquals(inputRecord.getTime("time_micros").toString(),
+                        bsonDocument.getString("time_micros").getValue());
+    Assert.assertEquals(inputRecord.getDate("date").atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                        bsonDocument.getDateTime("date").getValue());
+  }
+}

--- a/src/test/java/io/cdap/plugin/batch/source/BSONObjectToRecordTransformerTest.java
+++ b/src/test/java/io/cdap/plugin/batch/source/BSONObjectToRecordTransformerTest.java
@@ -24,6 +24,7 @@ import io.cdap.cdap.api.data.schema.Schema;
 import org.bson.BSONObject;
 import org.bson.types.BasicBSONList;
 import org.bson.types.Decimal128;
+import org.bson.types.ObjectId;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -332,5 +333,26 @@ public class BSONObjectToRecordTransformerTest {
 
     BSONObjectToRecordTransformer transformer = new BSONObjectToRecordTransformer(schema);
     transformer.transform(bsonObject);
+  }
+
+  @Test
+  public void testTransformBytesId() {
+    Schema schema = Schema.recordOf("schema", Schema.Field.of("_id", Schema.of(Schema.Type.BYTES)));
+
+    ObjectId expectedId = new ObjectId("5d55315ce63eaf3886d57760");
+    BSONObject bsonObject = BasicDBObjectBuilder.start()
+      .add("_id", expectedId)
+      .get();
+
+    BSONObjectToRecordTransformer transformer = new BSONObjectToRecordTransformer(schema);
+    StructuredRecord transformed = transformer.transform(bsonObject);
+    Assert.assertNotNull(transformed);
+
+    Object transformedIdValue = transformed.get("_id");
+    Assert.assertNotNull(transformedIdValue);
+    ObjectId transformedId = transformedIdValue instanceof ByteBuffer ? new ObjectId((ByteBuffer) transformedIdValue)
+      : new ObjectId((byte[]) transformedIdValue);
+
+    Assert.assertEquals(expectedId, transformedId);
   }
 }

--- a/widgets/MongoDB-batchsink.json
+++ b/widgets/MongoDB-batchsink.json
@@ -5,19 +5,74 @@
   "display-name": "MongoDB",
   "configuration-groups": [
     {
-      "label": "MongoDB Configuration",
+      "label": "Basic",
       "properties": [
         {
           "widget-type": "textbox",
           "label": "Reference Name",
-          "name": "referenceName"
+          "name": "referenceName",
+          "widget-attributes": {
+            "placeholder": "Name used to identify this sink for lineage"
+          }
         },
         {
           "widget-type": "textbox",
-          "label": "Connection String",
-          "name": "connectionString",
+          "label": "Host",
+          "name": "host"
+        },
+        {
+          "widget-type": "number",
+          "label": "Port",
+          "name": "port",
           "widget-attributes": {
-            "width": "large"
+            "default": "27017"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Database",
+          "name": "database"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Collection",
+          "name": "collection"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "ID Field",
+          "name": "idField"
+        }
+      ]
+    },
+    {
+      "label": "Credentials",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Username",
+          "name": "user"
+        },
+        {
+          "widget-type": "password",
+          "label": "Password",
+          "name": "password"
+        }
+      ]
+    },
+    {
+      "label": "Advanced",
+      "properties": [
+        {
+          "widget-type": "keyvalue",
+          "label": "Connection Arguments",
+          "name": "connectionArguments",
+          "widget-attributes": {
+            "showDelimiter": "false",
+            "key-placeholder": "Key",
+            "value-placeholder": "Value",
+            "kv-delimiter": "=",
+            "delimiter": ";"
           }
         }
       ]


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-15266
WIKI: https://wiki.cask.co/display/CE/MongoDB+database+plugin

In the scope of this PR:
* Sink config properties changed to match current plugin standards
* Sink validation changed to match current plugin standards
* Added unit tests for transformer and config
* Field-level lineage support added for the Sink
* All data types support added to the Sink 
* “ID Field” property added to the Sink 
* Sink tests updated
* Sample pipeline added

_Currently, the following data types are not supported for the Sink:_
* Undefined
* Regular Expression
* DBPointer
* JavaScript
* JavaScript (with scope)
* Timestamp ([special type for internal MongoDB use](https://docs.mongodb.com/manual/reference/bson-types/#timestamps))
* Min key
* Max key