### PR TITLE
[PLUGIN-1286] Adding support to read large data

### DIFF
--- a/src/main/java/io/cdap/plugin/batch/source/MongoDBBatchSource.java
+++ b/src/main/java/io/cdap/plugin/batch/source/MongoDBBatchSource.java
@@ -99,6 +99,8 @@ public class MongoDBBatchSource extends ReferenceBatchSource<Object, BSONObject,
       MongoConfigUtil.setAuthURI(conf, config.authConnectionString);
     }
 
+    MongoConfigUtil.setRangeQueryEnabled(conf, true);
+
     emitLineage(context);
     context.setInput(Input.of(config.getReferenceName(),
                               new SourceInputFormatProvider(MongoConfigUtil.getInputFormat(conf), conf)));


### PR DESCRIPTION
MongoDB plugin was failing to read data from MongoDB database when the collection size is larger than 2MB. 

The error originates when the data is split which uses min, max functions. Now we would be splitting using greater than equal to/less than instead of min/max.