### PR TITLE
[PLUGIN-1786] Changed getConnectionString to incorporate SRV fomrat

### DIFF
--- a/docs/MongoDB-batchsink.md
+++ b/docs/MongoDB-batchsink.md
@@ -26,6 +26,9 @@ automatically generated.
 
 **Password:** Password to use to connect to the specified database.
 
+**Connect Using SRV String:** Toggle to determine whether to use an SRV connection string for MongoDB. It can be
+enabled if the MongoDB deployment supports SRV DNS records for connection resolution.
+
 **Connection Arguments:** A list of arbitrary string key/value pairs as connection arguments. See
 [Connection String Options] for a full description of these arguments.
 

--- a/docs/MongoDB-batchsource.md
+++ b/docs/MongoDB-batchsource.md
@@ -28,6 +28,9 @@ and use the [MongoDB extended JSON format] to represent non-native JSON data typ
 
 **Password:** Password to use to connect to the specified database.
 
+**Connect Using SRV String:** Toggle to determine whether to use an SRV connection string for MongoDB. It can be
+enabled if the MongoDB deployment supports SRV DNS records for connection resolution.
+
 **Authentication Connection String:** Optional MongoDB connection string to connect to the 'config' database of a
 sharded cluster. It can be omitted if username and password do not differ from the previously provided ones or if
 'config' database does not require authentication.

--- a/src/main/java/io/cdap/plugin/MongoDBConfig.java
+++ b/src/main/java/io/cdap/plugin/MongoDBConfig.java
@@ -160,8 +160,9 @@ public class MongoDBConfig extends PluginConfig {
     if (!containsMacro(MongoDBConstants.HOST) && Strings.isNullOrEmpty(host)) {
       throw new InvalidConfigPropertyException("Host must be specified", MongoDBConstants.HOST);
     }
-    if ((!containsMacro(MongoDBConstants.CONNECT_USING_SRV_STRING) && !connectUsingSRVString) &&
-      !containsMacro(MongoDBConstants.PORT)) {
+    if (!containsMacro(MongoDBConstants.PORT) && port != null && !containsMacro(
+        MongoDBConstants.CONNECT_USING_SRV_STRING) && connectUsingSRVString != null && !connectUsingSRVString) {
+      // Port is not required when SRV is used
       if (port < 1) {
         throw new InvalidConfigPropertyException("Port number must be greater than 0", MongoDBConstants.PORT);
       }

--- a/src/main/java/io/cdap/plugin/MongoDBConfig.java
+++ b/src/main/java/io/cdap/plugin/MongoDBConfig.java
@@ -50,7 +50,8 @@ public class MongoDBConfig extends PluginConfig {
   @Name(MongoDBConstants.PORT)
   @Description("Port that MongoDB is listening to.")
   @Macro
-  private int port;
+  @Nullable
+  private Integer port;
 
   @Name(MongoDBConstants.DATABASE)
   @Description("MongoDB database name.")
@@ -76,6 +77,13 @@ public class MongoDBConfig extends PluginConfig {
   @Nullable
   private String password;
 
+  @Name(MongoDBConstants.CONNECT_USING_SRV_STRING)
+  @Description("Toggle to determine whether to use an SRV connection string for MongoDB. It can be " +
+    "enabled if the MongoDB deployment supports SRV DNS records for connection resolution.")
+  @Macro
+  @Nullable
+  private boolean connectUsingSRVString;
+
   @Name(MongoDBConstants.CONNECTION_ARGUMENTS)
   @Description("A list of arbitrary string key/value pairs as connection arguments.")
   @Macro
@@ -83,7 +91,7 @@ public class MongoDBConfig extends PluginConfig {
   private String connectionArguments;
 
   public MongoDBConfig(String referenceName, String host, int port, String database, String collection, String user,
-                       String password, String connectionArguments) {
+                       String password, boolean connectUsingSRVString, String connectionArguments) {
     this.referenceName = referenceName;
     this.host = host;
     this.port = port;
@@ -91,6 +99,7 @@ public class MongoDBConfig extends PluginConfig {
     this.collection = collection;
     this.user = user;
     this.password = password;
+    this.connectUsingSRVString = connectUsingSRVString;
     this.connectionArguments = connectionArguments;
   }
 
@@ -102,7 +111,8 @@ public class MongoDBConfig extends PluginConfig {
     return host;
   }
 
-  public int getPort() {
+  @Nullable
+  public Integer getPort() {
     return port;
   }
 
@@ -122,6 +132,10 @@ public class MongoDBConfig extends PluginConfig {
   @Nullable
   public String getPassword() {
     return password;
+  }
+
+  public boolean connectUsingSRVString() {
+    return connectUsingSRVString;
   }
 
   @Nullable
@@ -146,7 +160,8 @@ public class MongoDBConfig extends PluginConfig {
     if (!containsMacro(MongoDBConstants.HOST) && Strings.isNullOrEmpty(host)) {
       throw new InvalidConfigPropertyException("Host must be specified", MongoDBConstants.HOST);
     }
-    if (!containsMacro(MongoDBConstants.PORT)) {
+    if ((!containsMacro(MongoDBConstants.CONNECT_USING_SRV_STRING) && !connectUsingSRVString) &&
+      !containsMacro(MongoDBConstants.PORT)) {
       if (port < 1) {
         throw new InvalidConfigPropertyException("Port number must be greater than 0", MongoDBConstants.PORT);
       }
@@ -161,24 +176,32 @@ public class MongoDBConfig extends PluginConfig {
 
   /**
    * Constructs a connection string such as: "mongodb://admin:password@localhost:27017/admin.analytics?key=value;"
-   * using host, port, username, password, database, collection and optional connection properties. In the case when
-   * username or password is not provided the connection string will not contain credentials:
+   * using host, port, username, password, database, collection and optional connection properties.
+   * If SRV is enabled, the connection string will use the "mongodb+srv://" protocol instead of "mongodb://".
+   * In the case when username or password is not provided, the connection string will not contain credentials:
    * "mongodb://localhost:27017/admin.analytics?key=value;"
+   * When SRV is not used, the port will be included in the connection string.
    *
    * @return connection string.
    */
   public String getConnectionString() {
-    StringBuilder connectionStringBuilder = new StringBuilder("mongodb://");
+    StringBuilder connectionStringBuilder = new StringBuilder();
+    if (connectUsingSRVString()) {
+      connectionStringBuilder.append("mongodb+srv://");
+    } else {
+      connectionStringBuilder.append("mongodb://");
+    }
     if (!Strings.isNullOrEmpty(user) || !Strings.isNullOrEmpty(password)) {
       connectionStringBuilder.append(user).append(":").append(password).append("@");
     }
-    connectionStringBuilder.append(host).append(":").append(port).append("/")
-      .append(database).append(".").append(collection);
-
+    connectionStringBuilder.append(host);
+    if (!connectUsingSRVString()) {
+      connectionStringBuilder.append(":").append(port);
+    }
+    connectionStringBuilder.append("/").append(database).append(".").append(collection);
     if (!Strings.isNullOrEmpty(connectionArguments)) {
       connectionStringBuilder.append("?").append(connectionArguments);
     }
-
     return connectionStringBuilder.toString();
   }
 

--- a/src/main/java/io/cdap/plugin/MongoDBConfig.java
+++ b/src/main/java/io/cdap/plugin/MongoDBConfig.java
@@ -82,7 +82,7 @@ public class MongoDBConfig extends PluginConfig {
     "enabled if the MongoDB deployment supports SRV DNS records for connection resolution.")
   @Macro
   @Nullable
-  private boolean connectUsingSRVString;
+  private Boolean connectUsingSRVString;
 
   @Name(MongoDBConstants.CONNECTION_ARGUMENTS)
   @Description("A list of arbitrary string key/value pairs as connection arguments.")

--- a/src/main/java/io/cdap/plugin/MongoDBConstants.java
+++ b/src/main/java/io/cdap/plugin/MongoDBConstants.java
@@ -80,6 +80,11 @@ public class MongoDBConstants {
   public static final String PASSWORD = "password";
 
   /**
+   * Configuration property name used to specify whether to use an SRV Connection string for MongoDB.
+   */
+  public static final String CONNECT_USING_SRV_STRING = "connectUsingSRVString";
+
+  /**
    * Configuration property name used to specify auxiliary MongoDB connection string to authenticate against when
    * constructing splits.
    */

--- a/src/main/java/io/cdap/plugin/batch/sink/MongoDBBatchSink.java
+++ b/src/main/java/io/cdap/plugin/batch/sink/MongoDBBatchSink.java
@@ -171,8 +171,10 @@ public class MongoDBBatchSink extends ReferenceBatchSink<StructuredRecord, NullW
     private String idField;
 
     public MongoDBSinkConfig(String referenceName, String host, int port, String database, String collection,
-                             String user, String password, String connectionArguments, String idField) {
-      super(referenceName, host, port, database, collection, user, password, connectionArguments);
+                             String user, String password, boolean connectUsingSRVString,
+                             String connectionArguments, String idField) {
+      super(referenceName, host, port, database, collection, user, password,
+            connectUsingSRVString, connectionArguments);
       this.idField = idField;
     }
 

--- a/src/main/java/io/cdap/plugin/batch/source/MongoDBBatchSource.java
+++ b/src/main/java/io/cdap/plugin/batch/source/MongoDBBatchSource.java
@@ -190,9 +190,11 @@ public class MongoDBBatchSource extends ReferenceBatchSource<Object, BSONObject,
     private String authConnectionString;
 
     public MongoDBSourceConfig(String referenceName, String host, int port, String database, String collection,
-                               String user, String password, String connectionArguments, String schema,
+                               String user, String password, boolean connectUsingSRVString,
+                               String connectionArguments, String schema,
                                String inputQuery, String onError, String authConnectionString) {
-      super(referenceName, host, port, database, collection, user, password, connectionArguments);
+      super(referenceName, host, port, database, collection, user, password,
+            connectUsingSRVString, connectionArguments);
       this.schema = schema;
       this.inputQuery = inputQuery;
       this.onError = onError;

--- a/src/test/java/io/cdap/plugin/batch/MongoDBConfigBuilder.java
+++ b/src/test/java/io/cdap/plugin/batch/MongoDBConfigBuilder.java
@@ -29,6 +29,7 @@ public class MongoDBConfigBuilder<T extends MongoDBConfigBuilder> {
   protected String collection;
   protected String user;
   protected String password;
+  protected boolean connectUsingSRVString;
   protected String connectionArguments;
 
   public static MongoDBConfigBuilder builder() {
@@ -82,12 +83,18 @@ public class MongoDBConfigBuilder<T extends MongoDBConfigBuilder> {
     return (T) this;
   }
 
+  public T setConnectUsingSRVString(boolean connectUsingSRVString) {
+    this.connectUsingSRVString = connectUsingSRVString;
+    return (T) this;
+  }
+
   public T setConnectionArguments(String connectionArguments) {
     this.connectionArguments = connectionArguments;
     return (T) this;
   }
 
   public MongoDBConfig build() {
-    return new MongoDBConfig(referenceName, host, port, database, collection, user, password, connectionArguments);
+    return new MongoDBConfig(referenceName, host, port, database, collection, user, password,
+                             connectUsingSRVString, connectionArguments);
   }
 }

--- a/src/test/java/io/cdap/plugin/batch/MongoDBConfigTest.java
+++ b/src/test/java/io/cdap/plugin/batch/MongoDBConfigTest.java
@@ -36,6 +36,7 @@ public class MongoDBConfigTest {
     .setCollection("analytics")
     .setUser("admin")
     .setPassword("password")
+    .setConnectUsingSRVString(false)
     .setConnectionArguments("key=value;")
     .build();
 
@@ -43,6 +44,16 @@ public class MongoDBConfigTest {
   public void testConfigConnectionString() {
     Assert.assertEquals("mongodb://admin:password@localhost:27017/admin.analytics?key=value;",
                         VALID_CONFIG.getConnectionString());
+  }
+
+  @Test
+  public void testConfigConnectionStringWithSRV() {
+    String connectionString = MongoDBConfigBuilder.builder(VALID_CONFIG)
+      .setConnectUsingSRVString(true)
+      .build()
+      .getConnectionString();
+
+    Assert.assertEquals("mongodb+srv://admin:password@localhost/admin.analytics?key=value;", connectionString);
   }
 
   @Test
@@ -54,6 +65,18 @@ public class MongoDBConfigTest {
       .getConnectionString();
 
     Assert.assertEquals("mongodb://localhost:27017/admin.analytics?key=value;", connectionString);
+  }
+
+  @Test
+  public void testConfigConnectionStringWithSRVNoCreds() {
+    String connectionString = MongoDBConfigBuilder.builder(VALID_CONFIG)
+      .setConnectUsingSRVString(true)
+      .setUser(null)
+      .setPassword(null)
+      .build()
+      .getConnectionString();
+
+    Assert.assertEquals("mongodb+srv://localhost/admin.analytics?key=value;", connectionString);
   }
 
   @Test

--- a/src/test/java/io/cdap/plugin/batch/sink/MongoDBSinkConfigBuilder.java
+++ b/src/test/java/io/cdap/plugin/batch/sink/MongoDBSinkConfigBuilder.java
@@ -49,6 +49,6 @@ public class MongoDBSinkConfigBuilder extends MongoDBConfigBuilder<MongoDBSinkCo
 
   public MongoDBBatchSink.MongoDBSinkConfig build() {
     return new MongoDBBatchSink.MongoDBSinkConfig(referenceName, host, port, database, collection, user, password,
-                                                  connectionArguments, idField);
+                                                  connectUsingSRVString, connectionArguments, idField);
   }
 }

--- a/src/test/java/io/cdap/plugin/batch/source/MongoDBSourceConfigBuilder.java
+++ b/src/test/java/io/cdap/plugin/batch/source/MongoDBSourceConfigBuilder.java
@@ -70,7 +70,7 @@ public class MongoDBSourceConfigBuilder extends MongoDBConfigBuilder<MongoDBSour
 
   public MongoDBBatchSource.MongoDBSourceConfig build() {
     return new MongoDBBatchSource.MongoDBSourceConfig(referenceName, host, port, database, collection, user, password,
-                                                      connectionArguments, schema, inputQuery, onError,
-                                                      authConnectionString);
+                                                      connectUsingSRVString, connectionArguments, schema, inputQuery,
+                                                      onError, authConnectionString);
   }
 }

--- a/widgets/MongoDB-batchsink.json
+++ b/widgets/MongoDB-batchsink.json
@@ -57,6 +57,22 @@
           "widget-type": "password",
           "label": "Password",
           "name": "password"
+        },
+        {
+          "widget-type": "toggle",
+          "label": "Connect Using SRV String",
+          "name": "connectUsingSRVString",
+          "widget-attributes": {
+            "on": {
+              "value": "true",
+              "label": "True"
+            },
+            "off": {
+              "value": "false",
+              "label": "False"
+            },
+            "default": "false"
+          }
         }
       ]
     },

--- a/widgets/MongoDB-batchsource.json
+++ b/widgets/MongoDB-batchsource.json
@@ -62,6 +62,22 @@
           "name": "password"
         },
         {
+          "widget-type": "toggle",
+          "label": "Connect Using SRV String",
+          "name": "connectUsingSRVString",
+          "widget-attributes": {
+            "on": {
+              "value": "true",
+              "label": "True"
+            },
+            "off": {
+              "value": "false",
+              "label": "False"
+            },
+            "default": "false"
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Authentication Connection String",
           "name": "authConnectionString",


### PR DESCRIPTION
[PLUGIN-1786](https://cdap.atlassian.net/browse/PLUGIN-1786)

- Incorporated SRV format in connection string and introduced a toggle property in MongoDB plugin UI.
<img width="1182" alt="image" src="https://github.com/user-attachments/assets/89c5a2a8-c01b-46be-b2e2-57ab1a51e193" />


[PLUGIN-1786]: https://cdap.atlassian.net/browse/PLUGIN-1786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ